### PR TITLE
Make drug label optional

### DIFF
--- a/therapy/models.py
+++ b/therapy/models.py
@@ -38,6 +38,7 @@ class Drug(Therapy):
     max_phase: Optional[PhaseEnum]
     withdrawn: Optional[bool]
     trade_name: Optional[str]
+    label: Optional[str]
 
 
 class DrugGroup(Therapy):


### PR DESCRIPTION
With https://github.com/cancervariants/therapy-normalization/pull/9/commits/464893ba4379fa11f3fa9d483a063862a954b368 the label might be null, which would cause an error if that field isn't optional.