### PR TITLE
Pull out table creation logic that was causing errors

### DIFF
--- a/therapy/database.py
+++ b/therapy/database.py
@@ -29,6 +29,7 @@ class Database:
             existing_tables = self.ddb_client.list_tables()['TableNames']
             self.create_therapies_table(existing_tables)
             self.create_meta_data_table(existing_tables)
+
         self.therapies = self.ddb.Table('therapy_concepts')
         self.metadata = self.ddb.Table('therapy_metadata')
         self.cached_sources = {}

--- a/therapy/query.py
+++ b/therapy/query.py
@@ -39,8 +39,7 @@ class Normalizer:
     and normalizes query input.
     """
 
-    def __init__(self, db_url: str = '', db_region: str = 'us-east-2',
-                 db_create_tables: bool = False):
+    def __init__(self, db_url: str = '', db_region: str = 'us-east-2'):
         """Initialize Normalizer instance.
 
         :param db_url: URL to database source.
@@ -48,8 +47,7 @@ class Normalizer:
         :param db_create_tables: flag to try to create tables if they don't
             already exist.
         """
-        self.db = Database(db_url=db_url, region_name=db_region,
-                           create_tables=db_create_tables)
+        self.db = Database(db_url=db_url, region_name=db_region)
 
     def emit_warnings(self, query_str) -> Optional[Dict]:
         """Emit warnings if query contains non breaking space characters."""


### PR DESCRIPTION
Noticed that I left an arg for forcing table creation in when it had been removed -- now, the db should automatically try to create tables if you give it an endpoint that isn't the AWS cloud (i.e. something local). We could also make it an explicit option, though.