### PR TITLE
fix normalize endpoint bug

### DIFF
--- a/therapy/main.py
+++ b/therapy/main.py
@@ -107,7 +107,7 @@ def normalize(q: str = Query(..., description=merged_q_descr)):
     :param q: therapy search term
     """
     try:
-        response = query_handler.search_groups(q)
+        response = query_handler.search_groups(html.unescape(q))
     except InvalidParameterException as e:
         raise HTTPException(status_code=422, detail=str(e))
     return response

--- a/therapy/query.py
+++ b/therapy/query.py
@@ -420,7 +420,7 @@ class QueryHandler:
         if query == '':
             response['match_type'] = MatchType.NO_MATCH
             return response
-        query_str = query.lower()
+        query_str = query.lower().strip()
 
         # check merged concept ID match
         record = self.db.get_record_by_id(query_str, case_sensitive=False,


### PR DESCRIPTION
`q = 'cisplatin'` returns a match but `q='cisplatin     '` does not. 