### PR TITLE
feat: add manual data extraction override rules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ install_requires =
     disease-normalizer >= 0.2.14
     ga4gh.vrsatile.pydantic >= 0.1.dev3
 
+[options.package_data]
+therapy =
+    therapy/etl/*
+
 [options.extras_require]
 test =
     tox

--- a/tests/unit/data/therapies.json
+++ b/tests/unit/data/therapies.json
@@ -3589,7 +3589,7 @@
     ]
   },
   {
-    "label_and_type": "baxiliximab##label",
+    "label_and_type": "basiliximab##label",
     "item_type": "label",
     "src_name": "Wikidata",
     "concept_id": "wikidata:Q418702"

--- a/tests/unit/data/therapies.json
+++ b/tests/unit/data/therapies.json
@@ -3568,5 +3568,19 @@
     ],
     "item_type": "identity",
     "src_name": "ChEMBL"
+  },
+  {
+    "label_and_type": "wikidata:q418702##identity",
+    "item_type": "identity",
+    "src_name": "Wikidata",
+    "label": "Basiliximab",
+    "concept_id": "wikidata:Q418702",
+    "aliases": ["SDZ-CHI-621", "CHI-621", "CHI621", "chimeric mouse-human antiCD25"],
+    "xrefs": [
+      "drugbank:DB00074",
+      "rxcui:196102",
+      "chembl:CHEMBL1201439",
+      "chemidplus:179045-86-4",
+    ],
   }
 ]

--- a/tests/unit/data/therapies.json
+++ b/tests/unit/data/therapies.json
@@ -3575,12 +3575,29 @@
     "src_name": "Wikidata",
     "concept_id": "wikidata:Q418702",
     "label": "Basiliximab",
-    "aliases": ["SDZ-CHI-621", "CHI-621", "CHI621", "chimeric mouse-human antiCD25"],
+    "aliases": [
+      "SDZ-CHI-621",
+      "CHI-621",
+      "CHI621",
+      "chimeric mouse-human antiCD25"
+    ],
     "xrefs": [
       "drugbank:DB00074",
       "rxcui:196102",
       "chembl:CHEMBL1201439",
       "chemidplus:179045-86-4"
     ]
+  },
+  {
+    "label_and_type": "baxiliximab##label",
+    "item_type": "label",
+    "src_name": "Wikidata",
+    "concept_id": "wikidata:Q418702"
+  },
+  {
+    "label_and_type": "chi621##alias",
+    "item_type": "alias",
+    "src_name": "Wikidata",
+    "concept_id": "wikidata:Q418702"
   }
 ]

--- a/tests/unit/data/therapies.json
+++ b/tests/unit/data/therapies.json
@@ -3573,14 +3573,14 @@
     "label_and_type": "wikidata:q418702##identity",
     "item_type": "identity",
     "src_name": "Wikidata",
-    "label": "Basiliximab",
     "concept_id": "wikidata:Q418702",
+    "label": "Basiliximab",
     "aliases": ["SDZ-CHI-621", "CHI-621", "CHI621", "chimeric mouse-human antiCD25"],
     "xrefs": [
       "drugbank:DB00074",
       "rxcui:196102",
       "chembl:CHEMBL1201439",
       "chemidplus:179045-86-4",
-    ],
+    ]
   }
 ]

--- a/tests/unit/data/therapies.json
+++ b/tests/unit/data/therapies.json
@@ -3580,7 +3580,7 @@
       "drugbank:DB00074",
       "rxcui:196102",
       "chembl:CHEMBL1201439",
-      "chemidplus:179045-86-4",
+      "chemidplus:179045-86-4"
     ]
   }
 ]

--- a/tests/unit/test_wikidata.py
+++ b/tests/unit/test_wikidata.py
@@ -153,27 +153,6 @@ def basiliximab():
     )
 
 
-def test_basiliximab(basiliximab, wikidata):
-    """Test that basiliximab terms resolve correctly"""
-    response = wikidata.search("wikidata:Q418702")
-    assert response.match_type == MatchType.CONCEPT_ID
-    assert len(response.records) == 1
-    compare_records(response.records[0], basiliximab)
-
-    response = wikidata.search("basiliximab")
-    assert response.match_type == MatchType.LABEL
-    assert len(response.records) == 1
-    compare_records(response.records[0], basiliximab)
-
-    response = wikidata.search("CHI621")
-    assert response.match_type == MatchType.ALIAS
-    assert len(response.records) == 1
-    compare_records(response.records[0], basiliximab)
-
-    response = wikidata.search("Ig gamma-1 chain C region")
-    assert response.match_type == MatchType.NO_MATCH
-
-
 def test_cisplatin(cisplatin, wikidata):
     """Test that cisplatin drug normalizes to correct drug concept."""
     response = wikidata.search("wikidata:Q412415")
@@ -344,6 +323,27 @@ def test_d_methamphetamine(d_methamphetamine, wikidata):
     assert response.match_type == MatchType.XREF
     assert len(response.records) == 1
     compare_records(response.records[0], d_methamphetamine)
+
+
+def test_basiliximab(basiliximab, wikidata):
+    """Test that basiliximab terms resolve correctly"""
+    response = wikidata.search("wikidata:Q418702")
+    assert response.match_type == MatchType.CONCEPT_ID
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("basiliximab")
+    assert response.match_type == MatchType.LABEL
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("CHI621")
+    assert response.match_type == MatchType.ALIAS
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("Ig gamma-1 chain C region")
+    assert response.match_type == MatchType.NO_MATCH
 
 
 def test_case_no_match(wikidata):

--- a/tests/unit/test_wikidata.py
+++ b/tests/unit/test_wikidata.py
@@ -12,14 +12,15 @@ from tests.conftest import compare_records
 @pytest.fixture(scope="module")
 def wikidata():
     """Build Wikidata normalizer test fixture."""
-    class QueryGetter:
 
+    class QueryGetter:
         def __init__(self):
             self.query_handler = QueryHandler()
 
         def search(self, query_str):
             resp = self.query_handler.search(query_str, keyed=True, incl="wikidata")
             return resp.source_matches["Wikidata"]
+
     return QueryGetter()
 
 
@@ -35,7 +36,7 @@ def cisplatin():
             "CIS-DDP",
             "cis-diamminedichloroplatinum(II)",
             "Platinol",
-            "Platinol-AQ"
+            "Platinol-AQ",
         ],
         "approval_ratings": [],
         "xrefs": [
@@ -44,10 +45,8 @@ def cisplatin():
             "rxcui:2555",
             "chemidplus:15663-27-1",
         ],
-        "associated_with": [
-            "pubchem.compound:5702198"
-        ],
-        "trade_names": []
+        "associated_with": ["pubchem.compound:5702198"],
+        "trade_names": [],
     }
     return Drug(**params)
 
@@ -67,17 +66,17 @@ def interferon_alfacon_1():
             "methionyl-interferon-consensus",
             "rCon-IFN",
             "Recombinant Consensus Interferon",
-            "Recombinant methionyl human consensus interferon"
+            "Recombinant methionyl human consensus interferon",
         ],
         "approval_ratings": [],
         "xrefs": [
             "chembl:CHEMBL1201557",
             "drugbank:DB00069",
             "rxcui:59744",
-            "chemidplus:118390-30-0"
+            "chemidplus:118390-30-0",
         ],
         "associated_with": [],
-        "trade_names": []
+        "trade_names": [],
     }
     return Drug(**params)
 
@@ -100,7 +99,7 @@ def d_methamphetamine():
         "associated_with": [
             "pubchem.compound:10836",
         ],
-        "trade_names": []
+        "trade_names": [],
     }
     return Drug(**params)
 
@@ -125,22 +124,54 @@ def atropine():
             "(3-Endo)-8-methyl-8-azabicyclo[3.2.1]oct-3-yl tropate",
             "[(1S,5R)-8-Methyl-8-azabicyclo[3.2.1]oct-3-yl] "
             "3-hydroxy-2-phenyl-propanoate",
-            "8-Methyl-8-azabicyclo[3.2.1]oct-3-yl "
-            "3-hydroxy-2-phenylpropanoate",
-            "8-Methyl-8-azabicyclo[3.2.1]oct-3-yl tropate"
+            "8-Methyl-8-azabicyclo[3.2.1]oct-3-yl " "3-hydroxy-2-phenylpropanoate",
+            "8-Methyl-8-azabicyclo[3.2.1]oct-3-yl tropate",
         ],
         "approval_ratings": [],
-        "xrefs": [
-            "drugbank:DB00572",
-            "chemidplus:51-55-8",
-            "rxcui:1223"
-        ],
+        "xrefs": ["drugbank:DB00572", "chemidplus:51-55-8", "rxcui:1223"],
         "associated_with": [
             "pubchem.compound:174174",
         ],
-        "trade_names": []
+        "trade_names": [],
     }
     return Drug(**params)
+
+
+@pytest.fixture(scope="module")
+def basiliximab():
+    """Create basiliximab test fixture to demonstrate rule-based filtering."""
+    return Drug(
+        label="Basiliximab",
+        concept_id="wikidata:Q418702",
+        aliases=["SDZ-CHI-621", "CHI-621", "CHI621", "chimeric mouse-human antiCD25"],
+        xrefs=[
+            "drugbank:DB00074",
+            "rxcui:196102",
+            "chembl:CHEMBL1201439",
+            "chemidplus:179045-86-4",
+        ],
+    )
+
+
+def test_basiliximab(basiliximab, wikidata):
+    """Test that basiliximab terms resolve correctly"""
+    response = wikidata.search("wikidata:Q418702")
+    assert response.match_type == MatchType.CONCEPT_ID
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("basiliximab")
+    assert response.match_type == MatchType.LABEL
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("CHI621")
+    assert response.match_type == MatchType.ALIAS
+    assert len(response.records) == 1
+    compare_records(response.records[0], basiliximab)
+
+    response = wikidata.search("Ig gamma-1 chain C region")
+    assert response.match_type == MatchType.NO_MATCH
 
 
 def test_cisplatin(cisplatin, wikidata):
@@ -335,13 +366,15 @@ def test_meta_info(wikidata):
     """Test that the meta field is correct."""
     response = wikidata.search("cisplatin")
     assert response.source_meta_.data_license == "CC0 1.0"
-    assert response.source_meta_.data_license_url == \
-           "https://creativecommons.org/publicdomain/zero/1.0/"
+    assert (
+        response.source_meta_.data_license_url
+        == "https://creativecommons.org/publicdomain/zero/1.0/"  # noqa: W503
+    )
     assert isodate.parse_date(response.source_meta_.version)
     assert response.source_meta_.data_url is None
     assert not response.source_meta_.rdp_url
     assert response.source_meta_.data_license_attributes == {
         "non_commercial": False,
         "share_alike": False,
-        "attribution": False
+        "attribution": False,
     }

--- a/therapy/etl/manual_override.csv
+++ b/therapy/etl/manual_override.csv
@@ -1,0 +1,9 @@
+source,concept_id,field,value
+Wikidata,wikidata:Q412920,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q3995913,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q412616,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q415392,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q415392,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q412323,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q415264,aliases,Ig gamma-1 chain C region
+Wikidata,wikidata:Q418702,aliases,Ig gamma-1 chain C region

--- a/therapy/etl/rules.py
+++ b/therapy/etl/rules.py
@@ -1,0 +1,66 @@
+"""Apply manual data restrictions and annotations to extracted records."""
+import csv
+from typing import Dict, Union, List
+
+from therapy import APP_ROOT
+from therapy.schemas import SourceName
+
+
+class Rules:
+    """Store manually-generated data rules for modifying extracted source data.
+
+    Use to provide consistency in edge cases for computational normalization, and
+    correct possible curation errors.
+
+    Initialize within each source's ETL class. This entails a small amount of repeated
+    work, and could be revisited if the rules CSV becomes truly large, but makes for
+    cleaner code in the meantime.
+
+    Currently used to delete specific parameters from listlike fields, but could be
+    expanded to use wildcards (e.g. to prohibit a value from being used in any field)
+    or to manually add custom values to a field.
+    """
+
+    def __init__(self, source_name: SourceName) -> None:
+        """Initialize rules class.
+        :param source_name: name of source to use, for filtering unneeded rules
+        """
+        rules_path = APP_ROOT / "etl" / "rules.csv"
+        self.rules = {}
+        with open(rules_path, "r") as rules_file:
+            reader = csv.DictReader(rules_file, delimiter=",")
+            for row in reader:
+                if row["source"] == source_name:
+                    concept_id = row["concept_id"]
+                    if not self.rules.get(concept_id):
+                        self.rules[concept_id] = [(row["field"], row["value"])]
+                    else:
+                        self.rules[concept_id].append((row["field"], row["value"]))
+
+    def apply_rules_to_therapy(self, therapy: Dict) -> Dict:
+        """Apply all rules to therapy. First find relevant rules, then call the
+        apply method.
+        :param therapy: therapy object from ETL base
+        :return: processed therapy object
+        """
+        relevant_rules = self.rules.get(therapy["concept_id"], [])
+        for rule in relevant_rules:
+            therapy = self._apply_rule_to_field(therapy, rule[0], rule[1])
+        return therapy
+
+    def _apply_rule_to_field(
+        self, therapy: Dict, field: str, value: Union[str, List, Dict, int, float]
+    ) -> Dict:
+        """Given a (field, value) rule, apply it to the given therapy object.
+        :param therapy: therapy object ready to load to DB
+        :param field: name of object property field to check
+        :param value: value to remove from field, if possible
+        :return: therapy object with rule applied
+        """
+        if field not in {"aliases", "trade_names", "xrefs", "associated_with"}:
+            raise Exception("Non-scalar fields currently not implemented")
+        field_data = set(therapy.get(field, []))
+        if value in field_data:
+            field_data.remove(value)
+            therapy[field] = list(field_data)
+        return therapy

--- a/therapy/etl/rules.py
+++ b/therapy/etl/rules.py
@@ -1,6 +1,6 @@
 """Apply manual data restrictions and annotations to extracted records."""
 import csv
-from typing import Dict, Union, List
+from typing import Dict, Union, List, Tuple
 
 from therapy import APP_ROOT
 from therapy.schemas import SourceName
@@ -26,7 +26,7 @@ class Rules:
         :param source_name: name of source to use, for filtering unneeded rules
         """
         rules_path = APP_ROOT / "etl" / "rules.csv"
-        self.rules = {}
+        self.rules: Dict[str, List[Tuple[str, str]]] = {}
         with open(rules_path, "r") as rules_file:
             reader = csv.DictReader(rules_file, delimiter=",")
             for row in reader:


### PR DESCRIPTION
close #269 
close #294 

As implemented, this just makes a simple framework for declaring prohibited values on specific fields for specific concepts. IE, if I enter a row in rules.csv, I'm saying "don't allow this value to be entered for this record".

I didn't do this work, but it could pretty easily expanded to add an `add/remove` column (ie, if that column says `add`, then add that value in that field for that record), or to handle the non-scalar properties eg labels. 