### PR TITLE
fix: Add test for DiseaseIndicationBase

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,6 +9,7 @@ jobs:
             AWS_SECRET_ACCESS_KEY: ${{ secrets.DUMMY_AWS_SECRET_ACCESS_KEY }}
             AWS_DEFAULT_REGION: us-east-2
             AWS_DEFAULT_OUTPUT: text
+            DISEASE_NORM_DB_URL: http://localhost:8002
             THERAPY_NORM_DB_URL: http://localhost:8002
             THERAPY_TEST: true
         strategy:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def pytest_collection_modifyitems(items):
         "test_database",
         "test_query",
         "test_emit_warnings",
+        "test_disease_indication"
     ]
     items.sort(key=lambda i: MODULE_ORDER.index(i.module.__name__))
 

--- a/tests/scripts/build_disease_normalizer_data.py
+++ b/tests/scripts/build_disease_normalizer_data.py
@@ -43,7 +43,7 @@ class SaveQueryHandler(DiseaseQueryHandler):
         """Normalize query term"""
         response = super().normalize(query)
         if response.disease_descriptor:
-            result = response.disease_descriptor.disease
+            result = response.disease_descriptor.disease_id
         else:
             result = None
         disease_normalizer_table[query.lower()] = result
@@ -61,5 +61,5 @@ h.disease_normalizer = disease_query_handler
 h.perform_etl(use_existing=True)
 
 
-with open(TEST_DATA_DIRECTORY / "disease_normalization_testTODO.json", "w") as f:
+with open(TEST_DATA_DIRECTORY / "disease_normalization.json", "w") as f:
     json.dump(disease_normalizer_table, f)

--- a/tests/unit/test_disease_indication.py
+++ b/tests/unit/test_disease_indication.py
@@ -23,30 +23,31 @@ class TestDiseaseIndication(DiseaseIndicationBase):
             self.load_disease_test_data()
 
     def load_disease_test_data(self):
-        """Load dummy disease data"""
+        """Load disease data"""
         disease = {
-            "label_and_type": "ncit:c1##identity",
+            "label_and_type": "mondo:0700110##identity",
             "item_type": "identity",
-            "src_name": "NCIt",
-            "merge_ref": "ncit:C1",
-            "concept_id": "ncit:C1",
-            "label": "test disease identity",
+            "src_name": "Mondo",
+            "concept_id": "mondo:0700110",
+            "label": "pneumonia, non-human animal",
+            "merge_ref": "mondo:07001110##merger"
         }
         self.disease_normalizer.db.diseases.put_item(Item=disease)
 
-        disease_merger = {
-            "label_and_type": "ncit:c1##merger",
-            "concept_id": "ncit:C1",
+        merge = {
+            "label_and_type": "mondo:0700110##merger",
             "item_type": "merger",
-            "label": "dummy disease merger",
+            "src_name": "Mondo",
+            "concept_id": "mondo:0700110",
+            "label": "pneumonia, non-human animal",
         }
-        self.disease_normalizer.db.diseases.put_item(Item=disease_merger)
+        self.disease_normalizer.db.diseases.put_item(Item=merge)
 
         source = {
-            "src_name": "NCIt",
+            "src_name": "Mondo",
             "data_license": "CC BY 4.0",
             "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",
-            "version": "1.0.0",
+            "version": "2022-10-11",
             "data_license_attributes": {
                 "non_commercial": False,
                 "share_alike": False,
@@ -74,7 +75,6 @@ class TestDiseaseIndication(DiseaseIndicationBase):
 
 def test_normalize_disease():
     """Test that DiseaseIndicationBase works correctly when normalizing diseases"""
-    if RUN_TEST:
-        dib = TestDiseaseIndication()
-        norm_disease = dib._normalize_disease("ncit:C1")
-        assert norm_disease == "ncit:C1"
+    dib = TestDiseaseIndication()
+    norm_disease = dib._normalize_disease("mondo:0700110")
+    assert norm_disease == "mondo:0700110"

--- a/tests/unit/test_disease_indication.py
+++ b/tests/unit/test_disease_indication.py
@@ -1,0 +1,80 @@
+"""Module for testing DiseaseIndicationBase. This is needed so we know if
+disease-normalizer introduced breaking changes. Should only run during CI tests.
+"""
+import os
+
+from disease.database import AWS_ENV_VAR_NAME
+from disease.query import QueryHandler as DiseaseQueryHandler
+
+from therapy.etl.base import DiseaseIndicationBase
+
+
+RUN_TEST = os.environ.get("THERAPY_TEST", "").lower() == "true" and AWS_ENV_VAR_NAME not in os.environ  # noqa: E501
+
+
+class TestDiseaseIndication(DiseaseIndicationBase):
+    """Test instance for DiseaseIndicationBase"""
+
+    def __init__(self):
+        """Initialize test TestDiseaseIndication"""
+        self.disease_normalizer = DiseaseQueryHandler()
+
+        if RUN_TEST:
+            self.load_disease_test_data()
+
+    def load_disease_test_data(self):
+        """Load dummy disease data"""
+        disease = {
+            "label_and_type": "ncit:c1##identity",
+            "item_type": "identity",
+            "src_name": "NCIt",
+            "merge_ref": "ncit:C1",
+            "concept_id": "ncit:C1",
+            "label": "test disease identity",
+        }
+        self.disease_normalizer.db.diseases.put_item(Item=disease)
+
+        disease_merger = {
+            "label_and_type": "ncit:c1##merger",
+            "concept_id": "ncit:C1",
+            "item_type": "merger",
+            "label": "dummy disease merger",
+        }
+        self.disease_normalizer.db.diseases.put_item(Item=disease_merger)
+
+        source = {
+            "src_name": "NCIt",
+            "data_license": "CC BY 4.0",
+            "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",
+            "version": "1.0.0",
+            "data_license_attributes": {
+                "non_commercial": False,
+                "share_alike": False,
+                "attribution": True
+            }
+        }
+        self.disease_normalizer.db.metadata.put_item(Item=source)
+
+    def _download_data():
+        """Implement abstract method"""
+        pass
+
+    def _http_download():
+        """Implement abstract method"""
+        pass
+
+    def _transform_data():
+        """Implement abstract method"""
+        pass
+
+    def _load_meta():
+        """Implement abstract method"""
+        pass
+
+
+def test_normalize_disease():
+    """Test that DiseaseIndicationBase works correctly when normalizing diseases"""
+    if RUN_TEST:
+        dib = TestDiseaseIndication()
+        norm_disease = dib._normalize_disease("ncit:C1")
+        assert norm_disease == "ncit:C1"

--- a/therapy/etl/base.py
+++ b/therapy/etl/base.py
@@ -328,7 +328,7 @@ class DiseaseIndicationBase(Base):
         """
         response = self.disease_normalizer.normalize(query)
         if response.match_type > 0:
-            return response.disease_descriptor.disease
+            return response.disease_descriptor.disease_id
         else:
             logger.warning(f"Failed to normalize disease term: {query}")
             return None

--- a/therapy/version.py
+++ b/therapy/version.py
@@ -1,2 +1,2 @@
 """Therapy normalizer version"""
-__version__ = "0.3.9"
+__version__ = "0.3.10"


### PR DESCRIPTION
Close #340 

Ugh sorry. Forgot that disease normalizer was monkey patched for CI tests, so thought I could get away with not running all the ETL methods. 🤦‍♀️  Going to run them now 😅 

I also removed a TODO from the build_disease_normalizer_data 