### PR TITLE
build: fix package name in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "therapy-normalizer"
+name = "thera-py"
 authors = [
     {name = "Alex Wagner"},
     {name = "Kori Kuzma"},


### PR DESCRIPTION
I think this is why the GH action release is failing