### PR TITLE
test: suppress noisy boto logs by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest test config tools."""
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Callable, List, Optional
@@ -33,6 +34,28 @@ def pytest_collection_modifyitems(items):
         "test_disease_indication",
     ]
     items.sort(key=lambda i: MODULE_ORDER.index(i.module.__name__))
+
+
+def pytest_addoption(parser):
+    """Add custom commands to pytest invocation.
+
+    See https://docs.pytest.org/en/7.1.x/reference/reference.html#parser
+    """
+    parser.addoption(
+        "--verbose-logs",
+        action="store_true",
+        default=False,
+        help="show noisy module logs",
+    )
+
+
+def pytest_configure(config):
+    """Configure pytest setup."""
+    logging.getLogger(__name__).error(config.getoption("--verbose-logs"))
+    if not config.getoption("--verbose-logs"):
+        logging.getLogger("botocore").setLevel(logging.ERROR)
+        logging.getLogger("boto3").setLevel(logging.ERROR)
+        logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 
 
 TEST_ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
On failure, tests print out a bunch of logs that aren't useful to us in 99.99% of cases (debug stuff about dynamo requests). This PR introduces a pytest arg `--verbose-logs`, which is false by default, that controls whether those logging statements are recorded (i.e. by default, running `pytest` will only log at the error level for botocore, boto3, and urllib).