### PR TITLE
style: fix ruff settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.2
+    rev: v0.1.6
     hooks:
       - id: ruff-format
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,6 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2
     hooks:
-      - id: ruff
       - id: ruff-format
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,15 +81,15 @@ src = ["src"]
 select = ["E", "W", "F", "ANN", "D", "N", "I"]
 fixable = ["I", "F401"]
 
+# ANN101 - missing-type-self
+# ANN003 - missing-type-kwargs
 # D203 - one-blank-line-before-class
 # D205 - blank-line-after-summary
 # D206 - indent-with-spaces*
 # D213 - multi-line-summary-second-line
-# D300 - triple-single-quotes
+# D300 - triple-single-quotes*
 # D400 - ends-in-period
 # D415 - ends-in-punctuation
-# ANN101 - missing-type-self
-# ANN003 - missing-type-kwargs
 # E111 - indentation-with-invalid-multiple*
 # E114 - indentation-with-invalid-multiple-comment*
 # E117 - over-indented*
@@ -97,8 +97,8 @@ fixable = ["I", "F401"]
 # W191 - tab-indentation*
 # *ignored for compatibility with formatter
 ignore = [
-    "D203", "D205", "D206", "D213", "D300", "D400", "D415",
     "ANN101", "ANN003",
+    "D203", "D205", "D206", "D213", "D300", "D400", "D415",
     "E111", "E114", "E117", "E501",
     "W191"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,34 +79,35 @@ src = ["src"]
 # pep8-naming (N)
 # isort (I)
 select = ["E", "W", "F", "ANN", "D", "N", "I"]
-
 fixable = ["I", "F401"]
 
 # D203 - one-blank-line-before-class
 # D205 - blank-line-after-summary
 # D206 - indent-with-spaces*
 # D213 - multi-line-summary-second-line
+# D300 - triple-single-quotes
 # D400 - ends-in-period
 # D415 - ends-in-punctuation
 # ANN101 - missing-type-self
 # ANN003 - missing-type-kwargs
-# E501 - line-too-long
+# E111 - indentation-with-invalid-multiple*
+# E114 - indentation-with-invalid-multiple-comment*
+# E117 - over-indented*
+# E501 - line-too-long*
 # W191 - tab-indentation*
 # *ignored for compatibility with formatter
-ignore = ["D203", "D205", "D206", "D213", "D400", "D415", "ANN101", "ANN003", "E501", "Q", "W191"]
+ignore = [
+    "D203", "D205", "D206", "D213", "D300", "D400", "D415",
+    "ANN101", "ANN003",
+    "E111", "E114", "E117", "E501",
+    "W191"
+]
 
 [tool.ruff.per-file-ignores]
 # ANN001 - missing-type-function-argument
 # ANN2 - missing-return-type
 # ANN201 - Missing type annotation
 # ANN102 - missing-type-cls
-# D103 - Missing docstring in public function
-# F821 - undefined-name
-# F401 - unused-import
-# I001 - Import block unsorted or unformatted
 # N805 - invalid-first-argument-name-for-method
 "tests/*" = ["ANN001", "ANN102", "ANN2"]
-"setup.py" = ["F821"]
-"*__init__.py" = ["F401"]
-"therapy/schemas.py" = ["ANN001", "ANN201", "N805"]
-"docs/source/conf.py" = ["D100", "I001", "D103", "ANN201", "ANN001"]
+"src/therapy/schemas.py" = ["ANN001", "ANN201", "N805"]

--- a/src/therapy/__init__.py
+++ b/src/therapy/__init__.py
@@ -3,7 +3,7 @@ import logging
 import re
 from pathlib import Path
 
-from .version import __version__
+from .version import __version__  # noqa: F401
 
 APP_ROOT: Path = Path(__file__).resolve().parents[0]
 logging.basicConfig(
@@ -18,7 +18,7 @@ class DownloadException(Exception):  # noqa: N818
     """Exception for failures relating to source file downloads."""
 
 
-from therapy.schemas import (  # noqa: E402, E501, I100, I202
+from therapy.schemas import (  # noqa: E402, I100, I202
     ItemTypes,
     NamespacePrefix,
     SourceName,

--- a/src/therapy/cli.py
+++ b/src/therapy/cli.py
@@ -19,7 +19,7 @@ from therapy.database import (
     Database,
     confirm_aws_db_use,
 )
-from therapy.etl import (  # noqa: F401, E501
+from therapy.etl import (  # noqa: F401
     ChEMBL,
     ChemIDplus,
     DrugBank,

--- a/src/therapy/etl/__init__.py
+++ b/src/therapy/etl/__init__.py
@@ -9,3 +9,16 @@ from .merge import Merge
 from .ncit import NCIt
 from .rxnorm import RxNorm
 from .wikidata import Wikidata
+
+__all__ = [
+    "ChEMBL",
+    "ChemIDplus",
+    "DrugBank",
+    "DrugsAtFDA",
+    "GuideToPHARMACOLOGY",
+    "HemOnc",
+    "Merge",
+    "NCIt",
+    "RxNorm",
+    "Wikidata",
+]

--- a/src/therapy/etl/base.py
+++ b/src/therapy/etl/base.py
@@ -200,7 +200,7 @@ class Base(ABC):
                     f"Unable to parse version value from {src_name} source data file "
                     f"located at {self._src_file.absolute().as_uri()} -- "
                     "check filename against schema defined in README: "
-                    "https://github.com/cancervariants/therapy-normalization#update-sources"  # noqa: E501
+                    "https://github.com/cancervariants/therapy-normalization#update-sources"
                 )
         else:
             self._version = self.get_latest_version()

--- a/src/therapy/etl/chemidplus.py
+++ b/src/therapy/etl/chemidplus.py
@@ -118,7 +118,7 @@ class ChemIDplus(Base):
         """Add source metadata."""
         meta = SourceMeta(
             data_license="custom",
-            data_license_url="https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",  # noqa: E501
+            data_license_url="https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",
             version=self._version,
             data_url="ftp://ftp.nlm.nih.gov/nlmdata/.chemidlease/",
             rdp_url=None,

--- a/src/therapy/etl/drugbank.py
+++ b/src/therapy/etl/drugbank.py
@@ -16,7 +16,7 @@ class DrugBank(Base):
     def _download_data(self) -> None:
         """Download DrugBank source data."""
         logger.info("Retrieving source data for DrugBank")
-        url = f"https://go.drugbank.com/releases/{self._version.replace('.', '-')}/downloads/all-drugbank-vocabulary"  # noqa: E501
+        url = f"https://go.drugbank.com/releases/{self._version.replace('.', '-')}/downloads/all-drugbank-vocabulary"
         csv_file = self._src_dir / f"drugbank_{self._version}.csv"
         self._http_download(url, csv_file, handler=self._zip_handler)
         logger.info("Successfully retrieved source data for DrugBank")

--- a/src/therapy/etl/drugsatfda.py
+++ b/src/therapy/etl/drugsatfda.py
@@ -21,7 +21,7 @@ class DrugsAtFDA(Base):
     def _download_data(self) -> None:
         """Download source data from instance-provided source URL."""
         logger.info("Retrieving source data for Drugs@FDA")
-        url = "https://download.open.fda.gov/drug/drugsfda/drug-drugsfda-0001-of-0001.json.zip"  # noqa: E501
+        url = "https://download.open.fda.gov/drug/drugsfda/drug-drugsfda-0001-of-0001.json.zip"
         outfile_path = self._src_dir / f"drugsatfda_{self._version}.json"
         self._http_download(url, outfile_path, handler=self._zip_handler)
         logger.info("Successfully retrieved source data for Drugs@FDA")
@@ -49,7 +49,7 @@ class DrugsAtFDA(Base):
         """Add Drugs@FDA metadata."""
         meta = {
             "data_license": "CC0",
-            "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",  # noqa: E501
+            "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
             "version": self._version,
             "data_url": "https://open.fda.gov/apis/drug/drugsfda/download/",
             "rdp_url": None,

--- a/src/therapy/etl/guidetopharmacology.py
+++ b/src/therapy/etl/guidetopharmacology.py
@@ -74,7 +74,7 @@ class GuideToPHARMACOLOGY(Base):
                         "Unable to parse GtoPdb version value from ligands file "
                         f"located at {ligands_file.absolute().as_uri()} -- check "
                         "filename against schema defined in README: "
-                        "https://github.com/cancervariants/therapy-normalization#update-sources"  # noqa: E501
+                        "https://github.com/cancervariants/therapy-normalization#update-sources"
                     )
                 check_mapping_file = (
                     self._src_dir / f"{prefix}_ligand_id_mapping_{version}.tsv"
@@ -88,7 +88,7 @@ class GuideToPHARMACOLOGY(Base):
                 raise FileNotFoundError(
                     "Unable to find complete GtoPdb data set with matching version "
                     "values. Check filenames against schema defined in README: "
-                    "https://github.com/cancervariants/therapy-normalization#update-sources"  # noqa: E501
+                    "https://github.com/cancervariants/therapy-normalization#update-sources"
                 )
         else:
             self._version = self.get_latest_version()

--- a/src/therapy/etl/hemonc.py
+++ b/src/therapy/etl/hemonc.py
@@ -73,7 +73,7 @@ class HemOnc(DiseaseIndicationBase):
                 "DATAVERSE_API_KEY. See "
                 "https://guides.dataverse.org/en/latest/user/account.html"
             )
-        url = "https://dataverse.harvard.edu//api/access/dataset/:persistentId/?persistentId=doi:10.7910/DVN/9CY9C6"  # noqa: E501
+        url = "https://dataverse.harvard.edu//api/access/dataset/:persistentId/?persistentId=doi:10.7910/DVN/9CY9C6"
         headers = {"X-Dataverse-key": api_key}
         self._http_download(url, self._src_dir, headers, self._zip_handler)
 
@@ -107,7 +107,7 @@ class HemOnc(DiseaseIndicationBase):
                         f"Unable to parse HemOnc version value from concepts file "
                         f"located at {concepts_file.absolute().as_uri()} -- check "
                         "filename against schema defined in README: "
-                        "https://github.com/cancervariants/therapy-normalization#update-sources"  # noqa: E501
+                        "https://github.com/cancervariants/therapy-normalization#update-sources"
                     )
                 other_files = (
                     self._src_dir / f"hemonc_rels_{version}.csv",
@@ -121,7 +121,7 @@ class HemOnc(DiseaseIndicationBase):
                 raise FileNotFoundError(
                     "Unable to find complete HemOnc data set with matching version "
                     "values. Check filenames against schema defined in README: "
-                    "https://github.com/cancervariants/therapy-normalization#update-sources"  # noqa: E501
+                    "https://github.com/cancervariants/therapy-normalization#update-sources"
                 )
             else:
                 self._src_files = src_files
@@ -144,7 +144,7 @@ class HemOnc(DiseaseIndicationBase):
             "data_license": "CC BY 4.0",
             "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",
             "version": self._version,
-            "data_url": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/9CY9C6",  # noqa: E501
+            "data_url": "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/9CY9C6",
             "rdp_url": None,
             "data_license_attributes": {
                 "non_commercial": False,

--- a/src/therapy/etl/ncit.py
+++ b/src/therapy/etl/ncit.py
@@ -41,7 +41,7 @@ class NCIt(Base):
             archive_url = f"{base_url}/archive/{self._version}_Release/{release_fname}"
             archive_try = requests.get(archive_url)
             if archive_try.status_code != 200:
-                old_archive_url = f"{base_url}/archive/20{self._version[0:2]}/{self._version}_Release/{release_fname}"  # noqa: E501
+                old_archive_url = f"{base_url}/archive/20{self._version[0:2]}/{self._version}_Release/{release_fname}"
                 old_archive_try = requests.get(old_archive_url)
                 if old_archive_try.status_code != 200:
                     msg = (

--- a/src/therapy/etl/rxnorm.py
+++ b/src/therapy/etl/rxnorm.py
@@ -353,7 +353,7 @@ class RxNorm(Base):
         """Add RxNorm metadata."""
         meta = SourceMeta(
             data_license="UMLS Metathesaurus",
-            data_license_url="https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",  # noqa: E501
+            data_license_url="https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",
             version=self._version,
             data_url=bioversions.resolve("rxnorm").homepage,
             rdp_url=None,

--- a/src/therapy/main.py
+++ b/src/therapy/main.py
@@ -39,7 +39,7 @@ def custom_openapi() -> Dict:
     openapi_schema["info"]["contact"] = {
         "name": "Alex H. Wagner",
         "email": "Alex.Wagner@nationwidechildrens.org",
-        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab",  # noqa: E501
+        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab",
     }
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/src/therapy/schemas.py
+++ b/src/therapy/schemas.py
@@ -270,7 +270,7 @@ class SourceMeta(BaseModel):
                 "data_license": "CC BY-SA 3.0",
                 "data_license_url": "https://creativecommons.org/licenses/by-sa/3.0/",
                 "version": "27",
-                "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",  # noqa: E501
+                "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",
                 "rdp_url": "http://reusabledata.org/chembl.html",
                 "data_license_attributes": {
                     "non_commercial": False,
@@ -300,7 +300,7 @@ class MatchesKeyed(BaseModel):
                     "data_license": "CC BY-SA 3.0",
                     "data_license_url": "https://creativecommons.org/licenses/by-sa/3.0/",
                     "version": "27",
-                    "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",  # noqa: E501
+                    "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",
                     "rdp_url": "http://reusabledata.org/chembl.html",
                     "data_license_attributes": {
                         "non_commercial": False,
@@ -333,7 +333,7 @@ class MatchesListed(BaseModel):
                     "data_license": "CC BY-SA 3.0",
                     "data_license_url": "https://creativecommons.org/licenses/by-sa/3.0/",
                     "version": "27",
-                    "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",  # noqa: E501
+                    "data_url": "http://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_27/",
                     "rdp_url": "http://reusabledata.org/chembl.html",
                     "data_license_attributes": {
                         "non_commercial": False,
@@ -417,7 +417,7 @@ class UnmergedNormalizationService(BaseNormalizationService):
                                 "aliases": [
                                     "L-745,870",
                                     "L 745870",
-                                    "3-[[4-(4-chlorophenyl)piperazin-1-yl]methyl]-1H-pyrrolo[2,3-b]pyridine",  # noqa: E501
+                                    "3-[[4-(4-chlorophenyl)piperazin-1-yl]methyl]-1H-pyrrolo[2,3-b]pyridine",
                                 ],
                                 "trade_names": [],
                                 "xrefs": [
@@ -436,9 +436,9 @@ class UnmergedNormalizationService(BaseNormalizationService):
                         ],
                         "source_meta_": {
                             "data_license": "CC BY-SA 4.0",
-                            "data_license_url": "https://creativecommons.org/licenses/by-sa/4.0/",  # noqa: E501
+                            "data_license_url": "https://creativecommons.org/licenses/by-sa/4.0/",
                             "version": "2021.4",
-                            "data_url": "https://www.guidetopharmacology.org/download.jsp",  # noqa: E501
+                            "data_url": "https://www.guidetopharmacology.org/download.jsp",
                             "rdp_url": None,
                             "data_license_attributes": {
                                 "non_commercial": False,
@@ -463,9 +463,9 @@ class UnmergedNormalizationService(BaseNormalizationService):
                         ],
                         "source_meta_": {
                             "data_license": "CC BY-SA 3.0",
-                            "data_license_url": "https://creativecommons.org/licenses/by-sa/3.0/",  # noqa: E501
+                            "data_license_url": "https://creativecommons.org/licenses/by-sa/3.0/",
                             "version": "29",
-                            "data_url": "ftp://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_29",  # noqa: E501
+                            "data_url": "ftp://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_29",
                             "rdp_url": "http://reusabledata.org/chembl.html",
                             "data_license_attributes": {
                                 "non_commercial": False,
@@ -592,9 +592,9 @@ class NormalizationService(BaseNormalizationService):
                 "source_meta_": {
                     "RxNorm": {
                         "data_license": "UMLS Metathesaurus",
-                        "data_license_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",  # noqa: E501
+                        "data_license_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",
                         "version": "20210104",
-                        "data_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html",  # noqa: E501
+                        "data_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html",
                         "rdp_url": None,
                         "data_license_attributes": {
                             "non_commercial": False,
@@ -604,9 +604,9 @@ class NormalizationService(BaseNormalizationService):
                     },
                     "NCIt": {
                         "data_license": "CC BY 4.0",
-                        "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",  # noqa: E501
+                        "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",
                         "version": "20.09d",
-                        "data_url": "https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/archive/20.09d_Release/",  # noqa: E501
+                        "data_url": "https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/archive/20.09d_Release/",
                         "rdp_url": "http://reusabledata.org/ncit.html",
                         "data_license_attributes": {
                             "non_commercial": False,
@@ -616,7 +616,7 @@ class NormalizationService(BaseNormalizationService):
                     },
                     "ChemIDplus": {
                         "data_license": "custom",
-                        "data_license_url": "https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",  # noqa: E501
+                        "data_license_url": "https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",
                         "version": "20200327",
                         "data_url": "ftp://ftp.nlm.nih.gov/nlmdata/.chemidlease/",
                         "rdp_url": None,
@@ -628,7 +628,7 @@ class NormalizationService(BaseNormalizationService):
                     },
                     "Wikidata": {
                         "data_license": "CC0 1.0",
-                        "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",  # noqa: E501
+                        "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
                         "version": "20200812",
                         "data_url": None,
                         "rdp_url": None,
@@ -683,7 +683,7 @@ class SearchService(BaseModel):
                         ],
                         "source_meta_": {
                             "data_license": "custom",
-                            "data_license_url": "https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",  # noqa: E501
+                            "data_license_url": "https://www.nlm.nih.gov/databases/download/terms_and_conditions.html",
                             "version": "20210204",
                             "data_url": "ftp://ftp.nlm.nih.gov/nlmdata/.chemidlease/",
                             "rdp_url": None,
@@ -734,9 +734,9 @@ class SearchService(BaseModel):
                         ],
                         "source_meta_": {
                             "data_license": "UMLS Metathesaurus",
-                            "data_license_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",  # noqa: E501
+                            "data_license_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/termsofservice.html",
                             "version": "20210104",
-                            "data_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html",  # noqa: E501
+                            "data_url": "https://www.nlm.nih.gov/research/umls/rxnorm/docs/rxnormfiles.html",
                             "rdp_url": None,
                             "data_license_attributes": {
                                 "non_commercial": False,
@@ -765,9 +765,9 @@ class SearchService(BaseModel):
                         ],
                         "source_meta_": {
                             "data_license": "CC BY 4.0",
-                            "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",  # noqa: E501
+                            "data_license_url": "https://creativecommons.org/licenses/by/4.0/legalcode",
                             "version": "20.09d",
-                            "data_url": "https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/archive/2020/20.09d_Release/",  # noqa: E501
+                            "data_url": "https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/archive/2020/20.09d_Release/",
                             "rdp_url": "http://reusabledata.org/ncit.html",
                             "data_license_attributes": {
                                 "non_commercial": False,
@@ -804,7 +804,7 @@ class SearchService(BaseModel):
                         ],
                         "source_meta_": {
                             "data_license": "CC0 1.0",
-                            "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",  # noqa: E501
+                            "data_license_url": "https://creativecommons.org/publicdomain/zero/1.0/",
                             "version": "20210331",
                             "data_url": None,
                             "rdp_url": None,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -2,14 +2,14 @@
 from boto3.dynamodb.conditions import Key
 
 
-def test_tables_created(db):  # noqa: F811
+def test_tables_created(db):
     """Check that therapy_concepts and therapy_metadata are created."""
     existing_tables = db.dynamodb_client.list_tables()["TableNames"]
     assert "therapy_concepts" in existing_tables
     assert "therapy_metadata" in existing_tables
 
 
-def test_item_type(db):  # noqa: F811
+def test_item_type(db):
     """Check that objects are tagged with item_type attribute."""
     filter_exp = Key("label_and_type").eq("chembl:chembl11359##identity")
     item = db.therapies.query(KeyConditionExpression=filter_exp)["Items"][0]

--- a/tests/unit/test_guidetopharmacology.py
+++ b/tests/unit/test_guidetopharmacology.py
@@ -44,7 +44,7 @@ def arginine_vasotocin():
             "inchikey:OXDZADMCOWPSOC-ICBIOJHSSA-N",
         ],
         "aliases": [
-            "L-cysteinyl-L-tyrosyl-(3S)-DL-isoleucyl-L-glutaminyl-L-asparagyl-L-cysteinyl-DL-prolyl-L-arginyl-glycinamide (1->6)-disulfide",  # noqa: E501
+            "L-cysteinyl-L-tyrosyl-(3S)-DL-isoleucyl-L-glutaminyl-L-asparagyl-L-cysteinyl-DL-prolyl-L-arginyl-glycinamide (1->6)-disulfide",
             "argiprestocin",
             "[Arg8]vasotocin",
             "AVT",
@@ -97,7 +97,7 @@ def cisapride():
             "drugcentral:660",
         ],
         "aliases": [
-            "4-amino-5-chloro-N-[1-[3-(4-fluorophenoxy)propyl]-3-methoxypiperidin-4-yl]-2-methoxybenzamide",  # noqa: E501
+            "4-amino-5-chloro-N-[1-[3-(4-fluorophenoxy)propyl]-3-methoxypiperidin-4-yl]-2-methoxybenzamide",
             "Prepulsid",
             "Propulsid",
         ],

--- a/tests/unit/test_ncit.py
+++ b/tests/unit/test_ncit.py
@@ -116,7 +116,7 @@ def ivermectin():
         "aliases": [
             "Stromectol",
             "IVERMECTIN",
-            "Avermectin A1a, 5-O-demethyl-25-de(1-methylpropyl)-22,23-dihydro-25-(1-methylethyl)-",  # noqa: E501
+            "Avermectin A1a, 5-O-demethyl-25-de(1-methylpropyl)-22,23-dihydro-25-(1-methylethyl)-",
             "Sklice",
         ],
         "xrefs": ["chemidplus:70288-86-7"],

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -290,7 +290,7 @@ def test_search_sources(search_handler):
     assert set(resp.source_matches.keys()) == {"ChEMBL", "NCIt"}
 
     # test full inclusion
-    sources = "chembl,ncit,drugbank,wikidata,rxnorm,chemidplus,hemonc,guidetopharmacology,drugsatfda"  # noqa: E501
+    sources = "chembl,ncit,drugbank,wikidata,rxnorm,chemidplus,hemonc,guidetopharmacology,drugsatfda"
     resp = search_handler.search("cisplatin", keyed=True, incl=sources, excl="")
     assert set(resp.source_matches.keys()) == {
         "Wikidata",
@@ -318,7 +318,7 @@ def test_search_sources(search_handler):
     }
 
     # test full exclusion
-    sources = "chembl,wikidata,drugbank,ncit,rxnorm,chemidplus,hemonc,guidetopharmacology,drugsatfda"  # noqa: E501
+    sources = "chembl,wikidata,drugbank,ncit,rxnorm,chemidplus,hemonc,guidetopharmacology,drugsatfda"
     resp = search_handler.search("cisplatin", keyed=True, excl=sources)
     assert set(resp.source_matches.keys()) == set()
 

--- a/tests/unit/test_wikidata.py
+++ b/tests/unit/test_wikidata.py
@@ -361,7 +361,7 @@ def test_meta_info(wikidata):
     assert response.source_meta_.data_license == "CC0 1.0"
     assert (
         response.source_meta_.data_license_url
-        == "https://creativecommons.org/publicdomain/zero/1.0/"  # noqa: W503
+        == "https://creativecommons.org/publicdomain/zero/1.0/"
     )
     assert isodate.parse_date(response.source_meta_.version)
     assert response.source_meta_.data_url is None


### PR DESCRIPTION
Somehow I managed to do this wrong, in a different way, on each repo

edit: actually did a few other things

* removed a bunch of `noqa` annotations for checks that we weren't using
* configured lint rules for updated compatibility with formatter, see https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
* cleaned up a few small unused/unrelated things