### PR TITLE
feat: set silent to False in CLI

### DIFF
--- a/src/therapy/cli.py
+++ b/src/therapy/cli.py
@@ -102,7 +102,7 @@ def _load_source(
         click.get_current_context().exit()
     SourceClass = eval(name.value)  # noqa: N806
 
-    source = SourceClass(database=db)
+    source = SourceClass(database=db, silent=False)
     try:
         processed_ids += source.perform_etl(use_existing)
     except EtlError as e:

--- a/src/therapy/version.py
+++ b/src/therapy/version.py
@@ -1,2 +1,2 @@
 """Therapy normalizer version"""
-__version__ = "0.5.0-dev1"
+__version__ = "0.5.0-dev2"


### PR DESCRIPTION
I'm working on updating ddb updates for therapy. It would be useful to see ETL progress in CW logs. 