### PR TITLE
docs: fix env var name for harvard dataverse api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export UMLS_API_KEY=12345-6789-abcdefg-hijklmnop  # make sure to replace with yo
 HemOnc.org data requires a Harvard Dataverse API token. You must create a user account on the [Harvard Dataverse website](https://dataverse.harvard.edu/), you can follow [these instructions](https://guides.dataverse.org/en/latest/user/account.html) to create an account and generate an API token. Once you have an API token, set the following environment variable:
 
 ```shell script
-export DATAVERSE_API_KEY=12345-6789-abcdefgh-hijklmnop  # make sure to replace with your key!
+export HARVARD_DATAVERSE_API_KEY=12345-6789-abcdefgh-hijklmnop  # make sure to replace with your key!
 ```
 
 #### Update source(s)

--- a/src/therapy/version.py
+++ b/src/therapy/version.py
@@ -1,2 +1,2 @@
 """Therapy normalizer version"""
-__version__ = "0.5.0-dev2"
+__version__ = "0.5.0-dev3"


### PR DESCRIPTION
close #399 

Location in wags-tails: https://github.com/GenomicMedLab/wags-tails/blob/main/src/wags_tails/hemonc.py#L79