### PR TITLE
feat: add progress bars/indicators to CLI ETL processes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,15 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-etl = ["disease-normalizer[etl]~=0.4.0.dev0", "owlready2", "rdflib", "wikibaseintegrator>=0.12.0", "wags-tails"]
+etl = [
+    "disease-normalizer[etl]~=0.4.0.dev0",
+    "owlready2",
+    "rdflib",
+    "wikibaseintegrator>=0.12.0",
+    "wags-tails",
+    "tqdm",
+    "rich"
+]
 test = ["pytest", "pytest-cov", "pytest-mock"]
 dev = ["pre-commit", "ruff==0.2.0", "lxml", "xmlformatter", "mypy", "types-pyyaml"]
 

--- a/src/therapy/cli.py
+++ b/src/therapy/cli.py
@@ -153,7 +153,7 @@ def _load_merge(db: AbstractDatabase, processed_ids: Set[str]) -> None:
         )
         click.get_current_context().exit()
 
-    merge = Merge(database=db)
+    merge = Merge(database=db, silent=False)
     click.echo("Constructing normalized records...")
     merge.create_merged_concepts(processed_ids)
     end = timer()

--- a/src/therapy/etl/base.py
+++ b/src/therapy/etl/base.py
@@ -100,6 +100,7 @@ class Base(ABC):
         merged concepts.
 
         :param use_existing: if True, don't try to retrieve latest source data
+        :param silent: if True, suppress all console output
         :return: list of concept IDs which were successfully processed and
             uploaded.
         """

--- a/src/therapy/etl/chembl.py
+++ b/src/therapy/etl/chembl.py
@@ -2,6 +2,8 @@
 import sqlite3
 from typing import Dict, List, Optional, Union
 
+from tqdm import tqdm
+
 from therapy.etl.base import DiseaseIndicationBase
 from therapy.schemas import ApprovalRating, NamespacePrefix, SourceMeta, SourceName
 
@@ -153,7 +155,7 @@ class ChEMBL(DiseaseIndicationBase):
         """
         self._cursor.execute(query)
 
-        for row in self._cursor:
+        for row in tqdm(list(self._cursor), ncols=80, disable=self._silent):
             appr_ratings = []
             max_phase = self._get_approval_rating(row["max_phase"])
             if max_phase is not None:

--- a/src/therapy/etl/chemidplus.py
+++ b/src/therapy/etl/chemidplus.py
@@ -7,6 +7,8 @@ import xml.etree.ElementTree as ElTree
 from pathlib import Path
 from typing import Generator
 
+from rich.console import Console
+
 from therapy.etl.base import Base
 from therapy.schemas import (
     DataLicenseAttributes,
@@ -39,54 +41,61 @@ class ChemIDplus(Base):
     def _transform_data(self) -> None:
         """Open dataset and prepare for loading into database."""
         parser = self.parse_xml(self._data_file, "Chemical")  # type: ignore
-        for chemical in parser:  # type: ignore
-            if "displayName" not in chemical.attrib:
-                continue
+        # there's no elegant way to get a row total in advance from parsed XML --
+        # use a rich Console to provide a static spinner instead
+        with Console(color_system=None).status(
+            "Loading ChemIDplus records...", spinner="dots"
+        ):
+            for chemical in parser:  # type: ignore
+                if "displayName" not in chemical.attrib:
+                    continue
 
-            # initial setup and get label
-            display_name = chemical.attrib["displayName"]
-            if not display_name or not re.search(TAGS_REGEX, display_name):
-                continue
-            label = re.sub(TAGS_REGEX, "", display_name)
-            params: RecordParams = {"label": label}
+                # initial setup and get label
+                display_name = chemical.attrib["displayName"]
+                if not display_name or not re.search(TAGS_REGEX, display_name):
+                    continue
+                label = re.sub(TAGS_REGEX, "", display_name)
+                params: RecordParams = {"label": label}
 
-            # get concept ID
-            reg_no = chemical.find("NumberList").find("CASRegistryNumber")
-            if not reg_no:
-                continue
-            params["concept_id"] = f"{NamespacePrefix.CASREGISTRY.value}:{reg_no.text}"
+                # get concept ID
+                reg_no = chemical.find("NumberList").find("CASRegistryNumber")
+                if not reg_no:
+                    continue
+                params[
+                    "concept_id"
+                ] = f"{NamespacePrefix.CASREGISTRY.value}:{reg_no.text}"
 
-            # get aliases
-            aliases = []
-            label_l = label.lower()
-            name_list = chemical.find("NameList")
-            if name_list:
-                for name in name_list.findall("NameOfSubstance"):
-                    text = name.text
-                    if text != display_name and text.lower() != label_l:
-                        aliases.append(re.sub(TAGS_REGEX, "", text))
-            params["aliases"] = aliases
+                # get aliases
+                aliases = []
+                label_l = label.lower()
+                name_list = chemical.find("NameList")
+                if name_list:
+                    for name in name_list.findall("NameOfSubstance"):
+                        text = name.text
+                        if text != display_name and text.lower() != label_l:
+                            aliases.append(re.sub(TAGS_REGEX, "", text))
+                params["aliases"] = aliases
 
-            # get xrefs and associated_with
-            params["xrefs"] = []
-            params["associated_with"] = []
-            locator_list = chemical.find("LocatorList")
-            if locator_list:
-                for loc in locator_list.findall("InternetLocator"):
-                    if loc.text == "DrugBank":
-                        db = (
-                            f"{NamespacePrefix.DRUGBANK.value}:"
-                            f"{loc.attrib['url'].split('/')[-1]}"
-                        )
-                        params["xrefs"].append(db)  # type: ignore
-                    elif loc.text == "FDA SRS":
-                        unii = (
-                            f"{NamespacePrefix.UNII.value}:"
-                            f"{loc.attrib['url'].split('/')[-1]}"
-                        )
-                        params["associated_with"].append(unii)  # type: ignore
+                # get xrefs and associated_with
+                params["xrefs"] = []
+                params["associated_with"] = []
+                locator_list = chemical.find("LocatorList")
+                if locator_list:
+                    for loc in locator_list.findall("InternetLocator"):
+                        if loc.text == "DrugBank":
+                            db = (
+                                f"{NamespacePrefix.DRUGBANK.value}:"
+                                f"{loc.attrib['url'].split('/')[-1]}"
+                            )
+                            params["xrefs"].append(db)  # type: ignore
+                        elif loc.text == "FDA SRS":
+                            unii = (
+                                f"{NamespacePrefix.UNII.value}:"
+                                f"{loc.attrib['url'].split('/')[-1]}"
+                            )
+                            params["associated_with"].append(unii)  # type: ignore
 
-            self._load_therapy(params)
+                self._load_therapy(params)
 
     def _load_meta(self) -> None:
         """Add source metadata."""

--- a/src/therapy/etl/drugbank.py
+++ b/src/therapy/etl/drugbank.py
@@ -2,6 +2,8 @@
 import csv
 from typing import Any, Dict
 
+from tqdm import tqdm
+
 from therapy.etl.base import Base
 from therapy.schemas import NamespacePrefix, SourceMeta, SourceName
 
@@ -28,9 +30,8 @@ class DrugBank(Base):
     def _transform_data(self) -> None:
         """Transform the DrugBank source."""
         with self._data_file.open() as file:  # type: ignore
-            reader = csv.reader(file)
-            next(reader)  # skip header
-            for row in reader:
+            reader = list(csv.reader(file))
+            for row in tqdm(reader[1:], ncols=80, disable=self._silent):
                 # get concept ID
                 params: Dict[str, Any] = {
                     "concept_id": f"{NamespacePrefix.DRUGBANK.value}:{row[0]}",

--- a/src/therapy/etl/drugsatfda.py
+++ b/src/therapy/etl/drugsatfda.py
@@ -3,6 +3,8 @@ import json
 import logging
 from typing import List, Optional
 
+from tqdm import tqdm
+
 from therapy.etl.base import Base
 from therapy.schemas import (
     ApprovalRating,
@@ -63,7 +65,7 @@ class DrugsAtFDA(Base):
         with self._data_file.open() as f:  # type: ignore
             data = json.load(f)["results"]
 
-        for result in data:
+        for result in tqdm(data, ncols=80, disable=self._silent):
             if "products" not in result:
                 continue
             products = result["products"]

--- a/src/therapy/etl/guidetopharmacology.py
+++ b/src/therapy/etl/guidetopharmacology.py
@@ -5,6 +5,7 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Union
 
+from tqdm import tqdm
 from wags_tails.guide_to_pharmacology import GtoPLigandPaths
 
 from therapy.etl.base import Base, SourceFormatError
@@ -38,7 +39,7 @@ class GuideToPHARMACOLOGY(Base):
         self._transform_ligands(data)
         self._transform_ligand_id_mappings(data)
 
-        for param in data.values():
+        for param in tqdm(data.values(), ncols=80, disable=self._silent):
             self._load_therapy(param)
 
     @staticmethod

--- a/src/therapy/etl/hemonc.py
+++ b/src/therapy/etl/hemonc.py
@@ -3,6 +3,7 @@ import csv
 import logging
 from typing import Dict, Tuple
 
+from tqdm import tqdm
 from wags_tails.hemonc import HemOncPaths
 
 from therapy.etl.base import DiseaseIndicationBase
@@ -211,5 +212,5 @@ class HemOnc(DiseaseIndicationBase):
         therapies = self._get_rels(therapies, brand_names, conditions)
         therapies = self._get_synonyms(therapies)
 
-        for therapy in therapies.values():
+        for therapy in tqdm(therapies.values(), ncols=80, disable=self._silent):
             self._load_therapy(therapy)

--- a/src/therapy/etl/ncit.py
+++ b/src/therapy/etl/ncit.py
@@ -4,6 +4,7 @@ from typing import Set
 
 import owlready2 as owl
 from owlready2.entity import ThingClass
+from tqdm import tqdm
 
 from therapy.etl.base import Base
 from therapy.schemas import NamespacePrefix, RecordParams, SourceMeta, SourceName
@@ -85,7 +86,11 @@ class NCIt(Base):
         uq_nodes = {ncit.C49236}  # add Therapeutic Procedure
         uq_nodes = self._get_desc_nodes(ncit.C1909, uq_nodes)
         uq_nodes = self._get_typed_nodes(uq_nodes, ncit)
-        for node in uq_nodes:
+        for node in tqdm(
+            uq_nodes,
+            ncols=80,
+            disable=self._silent,
+        ):
             concept_id = f"{NamespacePrefix.NCIT.value}:{node.name}"
             label = node.P108.first() if node.P108 else None
             aliases = node.P90.copy()  # prevent CallbackList error

--- a/src/therapy/etl/rxnorm.py
+++ b/src/therapy/etl/rxnorm.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import yaml
+from tqdm import tqdm
 from wags_tails import CustomData, RxNormData
 
 from therapy import ASSOC_WITH_SOURCES, ITEM_TYPES, XREF_SOURCES
@@ -140,7 +141,7 @@ class RxNorm(Base):
                             )
                             self._add_xref_assoc(params, row)
 
-            for value in data.values():
+            for value in tqdm(data.values(), ncols=80, disable=self._silent):
                 if "label" in value:
                     self._get_trade_names(
                         value, precise_ingredient, ingredient_brands, sbdfs

--- a/src/therapy/etl/wikidata.py
+++ b/src/therapy/etl/wikidata.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from tqdm import tqdm
 from wags_tails import CustomData, DataSource
 from wags_tails.utils.versioning import DATE_VERSION_PATTERN
 from wikibaseintegrator.wbi_helpers import execute_sparql_query
@@ -157,7 +158,7 @@ class Wikidata(Base):
     def _transform_data(self) -> None:
         """Transform the Wikidata source data."""
         with self._data_file.open() as f:
-            records = json.load(f)
+            records: Dict = json.load(f)
 
             items: Dict[str, Any] = {}
 
@@ -196,5 +197,5 @@ class Wikidata(Base):
                         items[concept_id]["aliases"] += record["aliases"].split(";;")
                     else:
                         items[concept_id]["aliases"] = record["aliases"].split(";;")
-        for item in items.values():
+        for item in tqdm(items.values(), ncols=80, disable=self._silent):
             self._load_therapy(item)


### PR DESCRIPTION
**Situation**: Updating the therapy normalizer locally takes a lot of time, particularly the ChEMBL import and normalized group generation. It can be hard to tell if the process is hung or not.

**Background**: Refreshing TheraPy is needed to create new data releases for DGIdb. This is done locally because it's not yet feasible to automate this process on the DGIdb server (would need a few new features from Thera-Py and some DGIdb scripting).

**Assessment**: Progress bars are an easy drop-in way to tell that import processes are continuing to progress.

**Recommendation**: Use TQDM where possible to show progress, and `rich.Status` otherwise.

close #312 