### PR TITLE
fix: use enum for source name to ensure proper pydantic serialization

### DIFF
--- a/src/therapy/query.py
+++ b/src/therapy/query.py
@@ -357,7 +357,7 @@ class QueryHandler:
 
         for src in sources:
             try:
-                src_name = PREFIX_LOOKUP[src]
+                src_name = SourceName(PREFIX_LOOKUP[src])
             except KeyError:
                 # not an imported source
                 continue


### PR DESCRIPTION
this was remarkably annoying to track down. It should fix https://github.com/cancervariants/metakb/issues/347