### PR TITLE
cicd: remove mypy checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -58,7 +58,3 @@ jobs:
 
       - name: Check style
         run: python3 -m ruff check . && ruff format --check .
-
-      - name: Check type correctness
-        if: ${{ always() }}
-        run: python3 -m mypy src/therapy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ etl = [
     "rich"
 ]
 test = ["pytest", "pytest-cov", "pytest-mock"]
-dev = ["pre-commit", "ruff==0.2.0", "lxml", "xmlformatter", "mypy", "types-pyyaml"]
+dev = ["pre-commit", "ruff==0.2.0", "lxml", "xmlformatter", "types-pyyaml"]
 
 [project.urls]
 Homepage = "https://github.com/cancervariants/therapy-normalization"
@@ -76,10 +76,6 @@ testpaths = ["tests"]
 
 [tool.coverage.run]
 branch = true
-
-[tool.mypy]
-plugins = "pydantic.mypy"
-ignore_missing_imports = true
 
 [tool.ruff]
 src = ["src"]


### PR DESCRIPTION
I still think it's helpful to run locally from time to time but I don't think it's efficient to be performing this check on only this repo. If we want to revisit, we should do so for all of our projects.