### PR TITLE
fix: add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ etl = [
     "wikibaseintegrator>=0.12.0",
     "wags-tails",
     "tqdm",
-    "rich"
+    "rich",
 ]
 test = ["pytest", "pytest-cov", "pytest-mock"]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0", "lxml", "xmlformatter", "types-pyyaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,9 @@ etl = [
     "wags-tails",
     "tqdm",
     "rich",
+    "pyyaml"
 ]
-test = ["pytest", "pytest-cov", "pytest-mock"]
+test = ["pytest", "pytest-cov", "pytest-mock", "isodate"]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0", "lxml", "xmlformatter", "types-pyyaml"]
 
 [project.urls]


### PR DESCRIPTION
It looks like we had forgotten to pin some dependencies many, many years ago and were getting away with it until recently