### PR TITLE
feat!: update models to vrs 2.0.0 community review ballot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ dependencies = [
     "uvicorn",
     "click",
     "boto3",
-    "ga4gh.vrs~=2.0.0a8",
+    "ga4gh.vrs==2.0.0a13",
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 etl = [
-    "disease-normalizer[etl]~=0.5.0",
+    "disease-normalizer[etl]~=0.7.0",
     "owlready2",
     "rdflib",
     "wikibaseintegrator>=0.12.0",

--- a/src/therapy/etl/base.py
+++ b/src/therapy/etl/base.py
@@ -286,7 +286,7 @@ class DiseaseIndicationBase(Base):
         if term in self._disease_cache:
             return self._disease_cache[term]
         response = self.disease_normalizer.normalize(term)
-        normalized_id = response.normalized_id
+        normalized_id = response.disease.primaryCode.root if response.disease else None
         self._disease_cache[term] = normalized_id
         if normalized_id is None:
             _logger.warning("Failed to normalize disease term: %s", query)

--- a/src/therapy/main.py
+++ b/src/therapy/main.py
@@ -74,7 +74,7 @@ normalize_description = (
     "Return merged strongest-match concept for query string " "provided by user."
 )
 merged_matches_summary = (
-    "Given query, provide merged normalized record as a " "Therapeutic Agent."
+    "Given query, provide merged normalized record as a Therapy Mappable Concept."
 )
 merged_response_descr = "A response to a validly-formed query."
 normalize_q_descr = "Therapy to normalize."
@@ -148,7 +148,7 @@ def normalize(
     :param q: therapy search term
     :param bool infer_namespace: if True, try to infer namespace from query term.
     :returns: JSON response with matching normalized record provided as a
-    Therapeutic Agent, and source metadata
+    Therapy Mappable Concept, and source metadata
     """
     try:
         response = query_handler.normalize(html.unescape(q), infer_namespace)

--- a/src/therapy/schemas.py
+++ b/src/therapy/schemas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum, IntEnum
 from typing import Any, Literal
 
-from ga4gh.core import domain_models
+from ga4gh.core.models import MappableConcept
 from pydantic import BaseModel, ConfigDict, StrictBool, constr
 
 from therapy import __version__
@@ -485,7 +485,7 @@ class NormalizationService(BaseNormalizationService):
     """Response containing one or more merged records and source data."""
 
     normalized_id: str | None = None
-    therapeutic_agent: domain_models.TherapeuticAgent | None = None
+    therapy: MappableConcept | None = None
     source_meta_: dict[SourceName, SourceMeta] | None = None
 
     model_config = ConfigDict(
@@ -495,8 +495,8 @@ class NormalizationService(BaseNormalizationService):
                 "warnings": None,
                 "match_type": 80,
                 "normalized_id": "rxcui:2555",
-                "therapeutic_agent": {
-                    "type": "TherapeuticAgent",
+                "therapy": {
+                    "type": "Therapy",
                     "id": "normalize.therapy.rxcui:2555",
                     "label": "cisplatin",
                     "mappings": [

--- a/src/therapy/schemas.py
+++ b/src/therapy/schemas.py
@@ -258,6 +258,44 @@ class NamespacePrefix(Enum):
     WIKIDATA = "wikidata"
 
 
+# Source to URI. Will use OBO Foundry persistent URL (PURL) or source homepage
+NAMESPACE_TO_SYSTEM_URI: dict[NamespacePrefix, str] = {
+    NamespacePrefix.ATC: "https://www.who.int/tools/atc-ddd-toolkit/atc-classification/",
+    NamespacePrefix.CHEBI: "http://purl.obolibrary.org/obo/chebi.owl",
+    NamespacePrefix.CHEMBL: "https://www.ebi.ac.uk/chembl/",
+    NamespacePrefix.CHEMIDPLUS: "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus",
+    NamespacePrefix.CASREGISTRY: "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus",
+    NamespacePrefix.CVX: "https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx",
+    NamespacePrefix.DRUGBANK: "https://go.drugbank.com",
+    NamespacePrefix.DRUGCENTRAL: "https://drugcentral.org",
+    NamespacePrefix.DRUGSATFDA_ANDA: "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda",
+    NamespacePrefix.DRUGSATFDA_NDA: "https://www.fda.gov/drugs/types-applications/new-drug-application-nda",
+    NamespacePrefix.HEMONC: "https://hemonc.org",
+    NamespacePrefix.INCHIKEY: "https://www.chemspider.com",
+    NamespacePrefix.IUPHAR_LIGAND: "https://www.guidetopharmacology.org/GRAC/LigandListForward",
+    NamespacePrefix.GUIDETOPHARMACOLOGY: "https://www.guidetopharmacology.org/GRAC/LigandListForward",
+    NamespacePrefix.MMSL: "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html",
+    NamespacePrefix.MSH: "https://id.nlm.nih.gov/mesh/",
+    NamespacePrefix.NCIT: "http://purl.obolibrary.org/obo/ncit.owl",
+    NamespacePrefix.NDC: "https://dps.fda.gov/ndc",
+    NamespacePrefix.PUBCHEMCOMPOUND: "https://pubchem.ncbi.nlm.nih.gov/docs/compounds",
+    NamespacePrefix.PUBCHEMSUBSTANCE: "https://pubchem.ncbi.nlm.nih.gov/docs/substances",
+    NamespacePrefix.RXNORM: "https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+    NamespacePrefix.SPL: "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources",
+    NamespacePrefix.UMLS: "https://www.nlm.nih.gov/research/umls/index.html",
+    NamespacePrefix.UNII: "https://precision.fda.gov/uniisearch",
+    NamespacePrefix.UNIPROT: "https://www.uniprot.org",
+    NamespacePrefix.USP: "https://www.usp.org/health-quality-safety/compendial-nomenclature",
+    NamespacePrefix.VANDF: "https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/VANDF",
+    NamespacePrefix.WIKIDATA: "https://www.wikidata.org",
+}
+
+# URI to source
+SYSTEM_URI_TO_NAMESPACE = {
+    system_uri: ns.value for ns, system_uri in NAMESPACE_TO_SYSTEM_URI.items()
+}
+
+
 class DataLicenseAttributes(BaseModel):
     """Define constraints for data license attributes."""
 
@@ -484,7 +522,6 @@ class UnmergedNormalizationService(BaseNormalizationService):
 class NormalizationService(BaseNormalizationService):
     """Response containing one or more merged records and source data."""
 
-    normalized_id: str | None = None
     therapy: MappableConcept | None = None
     source_meta_: dict[SourceName, SourceMeta] | None = None
 
@@ -494,18 +531,31 @@ class NormalizationService(BaseNormalizationService):
                 "query": "cisplatin",
                 "warnings": None,
                 "match_type": 80,
-                "normalized_id": "rxcui:2555",
                 "therapy": {
-                    "type": "Therapy",
+                    "conceptType": "Therapy",
+                    "primaryCode": "rxcui:2555",
                     "id": "normalize.therapy.rxcui:2555",
                     "label": "cisplatin",
                     "mappings": [
                         {
-                            "coding": {"code": "C376", "system": "ncit"},
+                            "coding": {
+                                "code": "2555",
+                                "system": "https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+                            },
+                            "relation": "exactMatch",
+                        },
+                        {
+                            "coding": {
+                                "code": "C376",
+                                "system": "http://purl.obolibrary.org/obo/ncit.owl",
+                            },
                             "relation": "relatedMatch",
                         },
                         {
-                            "coding": {"code": "15663-27-1", "system": "chemidplus"},
+                            "coding": {
+                                "code": "15663-27-1",
+                                "system": "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus",
+                            },
                             "relation": "relatedMatch",
                         },
                         {

--- a/tests/data/fixtures/query_fixtures.json
+++ b/tests/data/fixtures/query_fixtures.json
@@ -1,49 +1,52 @@
 {
   "normalize_cisplatin": {
-    "type": "TherapeuticAgent",
+    "conceptType": "Therapy",
     "label": "cisplatin",
     "description": null,
     "id": "normalize.therapy.rxcui:2555",
-    "alternativeLabels": [
-      "Liplacis",
-      "cis-diamminedichloroplatinum III",
-      "APRD00359",
-      "(sp-4-2)-diamminedichloroplatinum",
-      "cis-Diaminedichloroplatinum",
-      "CDDP",
-      "1,2-Diaminocyclohexaneplatinum II citrate",
-      "Platinol",
-      "Platinol-AQ",
-      "DDP",
-      "cis-platinum",
-      "cisplatino",
-      "PLATINUM, DIAMMINEDICHLORO-, (SP-4-2)-",
-      "Cis-diamminedichloroplatinum ii",
-      "INT230-6 COMPONENT CISPLATIN",
-      "Cis-diamminedichloroplatinum",
-      "DACP",
-      "Cis-DDP",
-      "cisplatinum",
-      "NSC 119875",
-      "cis-diamminedichloroplatinum(II)",
-      "Cis-platin",
-      "(SP-4-2)-DIAMMINEDICHLOROPLATINUM",
-      "NSC119875",
-      "CIS-DIAMMINEDICHLOROPLATINUM",
-      "NSC-119875",
-      "Cisplatinum",
-      "CIS-DIAMMINEDICHLOROPLATINUM II",
-      "INT-230-6 COMPONENT CISPLATIN",
-      "CIS-DDP",
-      "Peyrone's salt",
-      "Cis-platinum ii",
-      "CISplatin",
-      "Fauldiscipla",
-      "CISPLATIN",
-      "Cisplatin",
-      "Mitometh"
-    ],
     "extensions": [
+      {
+        "name": "aliases",
+        "value": [
+          "Liplacis",
+          "cis-diamminedichloroplatinum III",
+          "APRD00359",
+          "(sp-4-2)-diamminedichloroplatinum",
+          "cis-Diaminedichloroplatinum",
+          "CDDP",
+          "1,2-Diaminocyclohexaneplatinum II citrate",
+          "Platinol",
+          "Platinol-AQ",
+          "DDP",
+          "cis-platinum",
+          "cisplatino",
+          "PLATINUM, DIAMMINEDICHLORO-, (SP-4-2)-",
+          "Cis-diamminedichloroplatinum ii",
+          "INT230-6 COMPONENT CISPLATIN",
+          "Cis-diamminedichloroplatinum",
+          "DACP",
+          "Cis-DDP",
+          "cisplatinum",
+          "NSC 119875",
+          "cis-diamminedichloroplatinum(II)",
+          "Cis-platin",
+          "(SP-4-2)-DIAMMINEDICHLOROPLATINUM",
+          "NSC119875",
+          "CIS-DIAMMINEDICHLOROPLATINUM",
+          "NSC-119875",
+          "Cisplatinum",
+          "CIS-DIAMMINEDICHLOROPLATINUM II",
+          "INT-230-6 COMPONENT CISPLATIN",
+          "CIS-DDP",
+          "Peyrone's salt",
+          "Cis-platinum ii",
+          "CISplatin",
+          "Fauldiscipla",
+          "CISPLATIN",
+          "Cisplatin",
+          "Mitometh"
+        ]
+      },
       {
         "name": "regulatory_approval",
         "value": {
@@ -54,7 +57,9 @@
             "gtopdb_approved",
             "hemonc_approved"
           ],
-          "approval_year": ["1978"],
+          "approval_year": [
+            "1978"
+          ],
           "has_indication": [
             {
               "id": "hemonc:671",
@@ -74,7 +79,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "hemonc:645",
@@ -94,7 +99,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "hemonc:569",
@@ -114,7 +119,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013945",
@@ -134,7 +139,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D064129",
@@ -154,7 +159,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001661",
@@ -174,7 +179,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009369",
@@ -194,7 +199,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "EFO:0003868",
@@ -214,7 +219,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002294",
@@ -234,7 +239,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018281",
@@ -254,7 +259,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D004806",
@@ -274,7 +279,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D004938",
@@ -294,7 +299,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D055752",
@@ -314,7 +319,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007680",
@@ -334,7 +339,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002276",
@@ -354,7 +359,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018242",
@@ -374,7 +379,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D005185",
@@ -394,7 +399,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009190",
@@ -414,7 +419,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016403",
@@ -434,7 +439,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007674",
@@ -454,7 +459,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013274",
@@ -474,7 +479,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014565",
@@ -485,7 +490,7 @@
                   "value": "chembl_phase_3"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014523",
@@ -505,7 +510,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016411",
@@ -525,7 +530,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009373",
@@ -545,7 +550,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001005",
@@ -565,7 +570,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013953",
@@ -585,7 +590,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008107",
@@ -605,7 +610,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014846",
@@ -625,7 +630,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D031901",
@@ -645,7 +650,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D005706",
@@ -665,7 +670,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016545",
@@ -685,7 +690,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007012",
@@ -705,7 +710,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002292",
@@ -725,7 +730,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D004066",
@@ -745,7 +750,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008113",
@@ -765,7 +770,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "EFO:1000043",
@@ -785,7 +790,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D004067",
@@ -805,7 +810,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D015179",
@@ -825,7 +830,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010190",
@@ -845,7 +850,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D006258",
@@ -865,7 +870,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012208",
@@ -885,7 +890,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016483",
@@ -905,7 +910,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001932",
@@ -925,7 +930,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D021441",
@@ -945,7 +950,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002822",
@@ -965,7 +970,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D020250",
@@ -976,7 +981,7 @@
                   "value": "chembl_phase_3"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D058922",
@@ -996,7 +1001,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D015266",
@@ -1016,7 +1021,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013736",
@@ -1036,7 +1041,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D000077192",
@@ -1056,7 +1061,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014594",
@@ -1076,7 +1081,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D005833",
@@ -1096,7 +1101,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D052016",
@@ -1116,7 +1121,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "EFO:0005570",
@@ -1136,7 +1141,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009101",
@@ -1156,7 +1161,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002280",
@@ -1176,7 +1181,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009959",
@@ -1196,7 +1201,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009447",
@@ -1216,7 +1221,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007938",
@@ -1236,7 +1241,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010610",
@@ -1256,7 +1261,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008545",
@@ -1276,7 +1281,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D000306",
@@ -1296,7 +1301,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D006689",
@@ -1316,7 +1321,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002583",
@@ -1336,7 +1341,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002289",
@@ -1356,7 +1361,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009325",
@@ -1367,7 +1372,7 @@
                   "value": "chembl_phase_2"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018288",
@@ -1387,7 +1392,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D000230",
@@ -1407,7 +1412,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018287",
@@ -1427,7 +1432,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018240",
@@ -1447,7 +1452,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001943",
@@ -1467,7 +1472,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010996",
@@ -1478,7 +1483,7 @@
                   "value": "chembl_phase_3"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016543",
@@ -1498,7 +1503,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012468",
@@ -1518,7 +1523,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D006528",
@@ -1538,7 +1543,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008479",
@@ -1558,7 +1563,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013724",
@@ -1578,7 +1583,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010534",
@@ -1598,7 +1603,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010255",
@@ -1618,7 +1623,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018285",
@@ -1638,7 +1643,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018239",
@@ -1658,7 +1663,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010051",
@@ -1678,7 +1683,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008224",
@@ -1698,7 +1703,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D000077195",
@@ -1718,7 +1723,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008654",
@@ -1738,7 +1743,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018197",
@@ -1758,7 +1763,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018236",
@@ -1778,7 +1783,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D017728",
@@ -1798,7 +1803,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D000740",
@@ -1818,7 +1823,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D002277",
@@ -1838,7 +1843,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D010412",
@@ -1858,7 +1863,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012878",
@@ -1878,7 +1883,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012175",
@@ -1898,7 +1903,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012509",
@@ -1918,7 +1923,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018273",
@@ -1938,7 +1943,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008223",
@@ -1958,7 +1963,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008228",
@@ -1978,7 +1983,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008175",
@@ -1998,7 +2003,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001749",
@@ -2018,7 +2023,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D015459",
@@ -2038,7 +2043,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008527",
@@ -2058,7 +2063,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D016889",
@@ -2078,7 +2083,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013280",
@@ -2098,7 +2103,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D020522",
@@ -2118,7 +2123,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014987",
@@ -2129,7 +2134,7 @@
                   "value": "chembl_phase_1"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012516",
@@ -2149,7 +2154,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018312",
@@ -2169,7 +2174,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009303",
@@ -2189,7 +2194,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D005910",
@@ -2209,7 +2214,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018305",
@@ -2229,7 +2234,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009362",
@@ -2240,7 +2245,7 @@
                   "value": "chembl_phase_2"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D006103",
@@ -2260,7 +2265,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007822",
@@ -2280,7 +2285,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D055728",
@@ -2300,7 +2305,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D007119",
@@ -2320,7 +2325,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018278",
@@ -2340,7 +2345,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008288",
@@ -2360,7 +2365,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D018269",
@@ -2380,7 +2385,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D014062",
@@ -2400,7 +2405,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013964",
@@ -2420,7 +2425,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D046152",
@@ -2440,7 +2445,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D064726",
@@ -2460,7 +2465,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             }
           ]
         }
@@ -2909,7 +2914,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009503",
@@ -2929,7 +2934,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D003866",
@@ -2949,7 +2954,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D008223",
@@ -2969,7 +2974,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012559",
@@ -2989,7 +2994,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D004827",
@@ -3009,7 +3014,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D013226",
@@ -3029,7 +3034,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D009357",
@@ -3049,7 +3054,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D012640",
@@ -3069,7 +3074,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             },
             {
               "id": "mesh:D001007",
@@ -3089,7 +3094,7 @@
                   "relation": "relatedMatch"
                 }
               ],
-              "type": "Disease"
+              "conceptType": "Disease"
             }
           ]
         }
@@ -3103,6 +3108,48 @@
           "Eskabarb",
           "Solfoton",
           "Phenobarbitone"
+        ]
+      },
+      {
+        "name": "aliases",
+        "value": [
+          "PHENOBARBITAL",
+          "Phenemal",
+          "5-Ethyl-5-phenyl-2,4,6(1H,3H,5H)-pyrimidinetrione",
+          "phenobarbitone",
+          "Phenobarbitone",
+          "Phenobarbital civ",
+          "Phenylethylbarbituric Acid",
+          "phenobarb",
+          "PHENYLETHYLMALONYLUREA",
+          "Phenylethylbarbitursaeure",
+          "Phenylethylbarbitursäure",
+          "Phenobarbituric Acid",
+          "5-Ethyl-5-phenylbarbituric acid",
+          "PHENO",
+          "NSC-128143-",
+          "phenobarbital sodium",
+          "Phenylethylbarbiturate",
+          "Fenobarbital",
+          "phenobarbital",
+          "Phenobarbital",
+          "5-ethyl-5-phenyl-1,3-diazinane-2,4,6-trione",
+          "5-ethyl-5-phenylpyrimidine-2,4,6(1H,3H,5H)-trione",
+          "Luminal®",
+          "Phenylaethylbarbitursaeure",
+          "NSC-9848",
+          "5-ethyl-5-phenyl-2,4,6(1H,3H,5H)-pyrimidinetrione",
+          "5-Phenyl-5-ethylbarbituric acid",
+          "fenobarbital",
+          "NSC-128143",
+          "Luminal",
+          "Phenylethylmalonylurea",
+          "5-Ethyl-5-phenyl-pyrimidine-2,4,6-trione",
+          "Phenobarbitol",
+          "PHENobarbital",
+          "APRD00184",
+          "phenylethylbarbiturate",
+          "Phenyläthylbarbitursäure"
         ]
       }
     ],
@@ -3241,46 +3288,7 @@
         "relation": "relatedMatch"
       }
     ],
-    "type": "TherapeuticAgent",
-    "alternativeLabels": [
-      "PHENOBARBITAL",
-      "Phenemal",
-      "5-Ethyl-5-phenyl-2,4,6(1H,3H,5H)-pyrimidinetrione",
-      "phenobarbitone",
-      "Phenobarbitone",
-      "Phenobarbital civ",
-      "Phenylethylbarbituric Acid",
-      "phenobarb",
-      "PHENYLETHYLMALONYLUREA",
-      "Phenylethylbarbitursaeure",
-      "Phenylethylbarbitursäure",
-      "Phenobarbituric Acid",
-      "5-Ethyl-5-phenylbarbituric acid",
-      "PHENO",
-      "NSC-128143-",
-      "phenobarbital sodium",
-      "Phenylethylbarbiturate",
-      "Fenobarbital",
-      "phenobarbital",
-      "Phenobarbital",
-      "5-ethyl-5-phenyl-1,3-diazinane-2,4,6-trione",
-      "5-ethyl-5-phenylpyrimidine-2,4,6(1H,3H,5H)-trione",
-      "Luminal®",
-      "Phenylaethylbarbitursaeure",
-      "NSC-9848",
-      "5-ethyl-5-phenyl-2,4,6(1H,3H,5H)-pyrimidinetrione",
-      "5-Phenyl-5-ethylbarbituric acid",
-      "fenobarbital",
-      "NSC-128143",
-      "Luminal",
-      "Phenylethylmalonylurea",
-      "5-Ethyl-5-phenyl-pyrimidine-2,4,6-trione",
-      "Phenobarbitol",
-      "PHENobarbital",
-      "APRD00184",
-      "phenylethylbarbiturate",
-      "Phenyläthylbarbitursäure"
-    ]
+    "conceptType": "Therapy"
   },
   "normalize_spiramycin": {
     "id": "normalize.therapy.rxcui:9991",
@@ -3357,45 +3365,55 @@
         "relation": "relatedMatch"
       }
     ],
-    "type": "TherapeuticAgent",
-    "alternativeLabels": [
-      "Rovamycin",
-      "Spiramycin 1",
-      "Foromacidin A",
-      "SPIRAMYCIN",
-      "Spiramycin",
-      "Demycarosylturimycin H",
-      "Antibiotic 799",
-      "Rovamycine",
-      "(4R,5S,6R,7R,9R,10R,11E,13E,16R)-10-{[(2R,5S,6R)-5-(dimethylamino)-6-methyltetrahydro-2H-pyran-2-yl]oxy}-9,16-dimethyl-5-methoxy-2-oxo-7-(2-oxoethyl)oxacyclohexadeca-11,13-dien-6-yl 3,6-dideoxy-4-O-(2,6-dideoxy-3-C-methyl-alpha-L-ribo-hexopyranosyl)-3-(dimethylamino)-alpha-D-glucopyranoside",
-      "RP 5337",
-      "Provamycin",
-      "Spiramycin A",
-      "Spiramycin I",
-      "spiramycin I",
-      "Foromacidine A"
+    "conceptType": "Therapy",
+    "extensions": [
+      {
+        "name": "aliases",
+        "value": [
+          "Rovamycin",
+          "Spiramycin 1",
+          "Foromacidin A",
+          "SPIRAMYCIN",
+          "Spiramycin",
+          "Demycarosylturimycin H",
+          "Antibiotic 799",
+          "Rovamycine",
+          "(4R,5S,6R,7R,9R,10R,11E,13E,16R)-10-{[(2R,5S,6R)-5-(dimethylamino)-6-methyltetrahydro-2H-pyran-2-yl]oxy}-9,16-dimethyl-5-methoxy-2-oxo-7-(2-oxoethyl)oxacyclohexadeca-11,13-dien-6-yl 3,6-dideoxy-4-O-(2,6-dideoxy-3-C-methyl-alpha-L-ribo-hexopyranosyl)-3-(dimethylamino)-alpha-D-glucopyranoside",
+          "RP 5337",
+          "Provamycin",
+          "Spiramycin A",
+          "Spiramycin I",
+          "spiramycin I",
+          "Foromacidine A"
+        ]
+      }
     ]
   },
   "normalize_therapeutic_procedure": {
-    "type": "TherapeuticAgent",
+    "conceptType": "Therapy",
     "label": "Therapeutic Procedure",
     "description": null,
     "id": "normalize.therapy.ncit:C49236",
-    "alternativeLabels": [
-      "Therapeutic Interventions",
-      "any therapy",
-      "therapy",
-      "TX",
-      "TREAT",
-      "Therapeutic Method",
-      "Therapeutic",
-      "Treatment",
-      "Therapeutic Technique",
-      "Therapy",
-      "treatment_or_therapy",
-      "treatment or therapy",
-      "any_therapy",
-      "treatment"
+    "extensions": [
+      {
+        "name": "aliases",
+        "value": [
+          "Therapeutic Interventions",
+          "any therapy",
+          "therapy",
+          "TX",
+          "TREAT",
+          "Therapeutic Method",
+          "Therapeutic",
+          "Treatment",
+          "Therapeutic Technique",
+          "Therapy",
+          "treatment_or_therapy",
+          "treatment or therapy",
+          "any_therapy",
+          "treatment"
+        ]
+      }
     ],
     "mappings": [
       {
@@ -3433,7 +3451,9 @@
             ],
             "trade_names": [],
             "xrefs": [],
-            "associated_with": ["umls:C0087111"],
+            "associated_with": [
+              "umls:C0087111"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -3471,8 +3491,12 @@
               "Spiramycin I"
             ],
             "trade_names": [],
-            "xrefs": ["drugbank:DB06145"],
-            "associated_with": ["atc:J01FA02"],
+            "xrefs": [
+              "drugbank:DB06145"
+            ],
+            "associated_with": [
+              "atc:J01FA02"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -3506,8 +3530,13 @@
               "RP 5337"
             ],
             "trade_names": [],
-            "xrefs": ["chemidplus:8025-81-8"],
-            "associated_with": ["umls:C0037962", "unii:71ODY0V87H"],
+            "xrefs": [
+              "chemidplus:8025-81-8"
+            ],
+            "associated_with": [
+              "umls:C0037962",
+              "unii:71ODY0V87H"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -3540,7 +3569,9 @@
               "Demycarosylturimycin H"
             ],
             "trade_names": [],
-            "xrefs": ["chemidplus:24916-50-5"],
+            "xrefs": [
+              "chemidplus:24916-50-5"
+            ],
             "associated_with": [
               "inchikey:ACTOXUHEUCPTEW-CEUOBAOPSA-N",
               "unii:033ECH6IFG"
@@ -3571,7 +3602,9 @@
             "aliases": [],
             "trade_names": [],
             "xrefs": [],
-            "associated_with": ["unii:71ODY0V87H"],
+            "associated_with": [
+              "unii:71ODY0V87H"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -3595,14 +3628,18 @@
           {
             "concept_id": "wikidata:Q422265",
             "label": "spiramycin",
-            "aliases": ["spiramycin I"],
+            "aliases": [
+              "spiramycin I"
+            ],
             "trade_names": [],
             "xrefs": [
               "chemidplus:8025-81-8",
               "rxcui:9991",
               "chembl:CHEMBL1256397"
             ],
-            "associated_with": ["pubchem.compound:5356392"],
+            "associated_with": [
+              "pubchem.compound:5356392"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -3642,8 +3679,14 @@
               "Cis-DDP",
               "PLATINUM, DIAMMINEDICHLORO-, (SP-4-2)-"
             ],
-            "trade_names": ["Platinol", "Cisplatin"],
-            "xrefs": ["drugbank:DB12117", "drugbank:DB00515"],
+            "trade_names": [
+              "Platinol",
+              "Cisplatin"
+            ],
+            "xrefs": [
+              "drugbank:DB12117",
+              "drugbank:DB00515"
+            ],
             "associated_with": [
               "atc:L01XA01",
               "unii:Q20Q21Q62J",
@@ -3653,7 +3696,9 @@
               "vandf:4018139",
               "mmsl:d00195"
             ],
-            "approval_ratings": ["rxnorm_prescribable"],
+            "approval_ratings": [
+              "rxnorm_prescribable"
+            ],
             "approval_year": [],
             "has_indication": []
           }
@@ -3678,7 +3723,9 @@
             "label": "Cisplatin",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["chemidplus:15663-27-1"],
+            "xrefs": [
+              "chemidplus:15663-27-1"
+            ],
             "associated_with": [
               "CHEBI:27899",
               "unii:Q20Q21Q62J",
@@ -3719,10 +3766,16 @@
               "NSC119875"
             ],
             "trade_names": [],
-            "xrefs": ["rxcui:2555"],
+            "xrefs": [
+              "rxcui:2555"
+            ],
             "associated_with": [],
-            "approval_ratings": ["hemonc_approved"],
-            "approval_year": ["1978"],
+            "approval_ratings": [
+              "hemonc_approved"
+            ],
+            "approval_year": [
+              "1978"
+            ],
             "has_indication": [
               {
                 "disease_id": "hemonc:671",
@@ -3744,7 +3797,9 @@
                 "disease_id": "hemonc:645",
                 "disease_label": "Ovarian cancer",
                 "normalized_disease_id": "ncit:C7431",
-                "supplemental_info": { "regulatory_body": "FDA" }
+                "supplemental_info": {
+                  "regulatory_body": "FDA"
+                }
               }
             ]
           }
@@ -3775,7 +3830,9 @@
               "APRD00359"
             ],
             "trade_names": [],
-            "xrefs": ["chemidplus:15663-27-1"],
+            "xrefs": [
+              "chemidplus:15663-27-1"
+            ],
             "associated_with": [
               "inchikey:LXZZYRPGZAFOLE-UHFFFAOYSA-L",
               "unii:Q20Q21Q62J"
@@ -3787,9 +3844,13 @@
           {
             "concept_id": "drugbank:DB12117",
             "label": "Mitometh",
-            "aliases": ["DDP"],
+            "aliases": [
+              "DDP"
+            ],
             "trade_names": [],
-            "xrefs": ["chemidplus:107465-03-2"],
+            "xrefs": [
+              "chemidplus:107465-03-2"
+            ],
             "associated_with": [
               "unii:H8MTN7XVC2",
               "inchikey:MOTIYCLHZZLHHQ-UHFFFAOYSA-N"
@@ -3819,14 +3880,18 @@
             "label": "CISPLATIN",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["rxcui:309311"],
+            "xrefs": [
+              "rxcui:309311"
+            ],
             "associated_with": [
               "spl:adf5773e-9095-4cb4-a90f-72cbf82f4493",
               "ndc:0703-5748",
               "unii:Q20Q21Q62J",
               "ndc:0703-5747"
             ],
-            "approval_ratings": ["fda_prescription"],
+            "approval_ratings": [
+              "fda_prescription"
+            ],
             "approval_year": [],
             "has_indication": []
           },
@@ -3835,13 +3900,17 @@
             "label": "CISPLATIN",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["rxcui:309311"],
+            "xrefs": [
+              "rxcui:309311"
+            ],
             "associated_with": [
               "ndc:63323-103",
               "unii:Q20Q21Q62J",
               "spl:9b008181-ab66-db2f-e053-2995a90aad57"
             ],
-            "approval_ratings": ["fda_prescription"],
+            "approval_ratings": [
+              "fda_prescription"
+            ],
             "approval_year": [],
             "has_indication": []
           },
@@ -3850,14 +3919,18 @@
             "label": "CISPLATIN",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["rxcui:309311"],
+            "xrefs": [
+              "rxcui:309311"
+            ],
             "associated_with": [
               "ndc:0143-9505",
               "unii:Q20Q21Q62J",
               "ndc:0143-9504",
               "spl:2c569ef0-588f-4828-8b2d-03a2120c9b4c"
             ],
-            "approval_ratings": ["fda_prescription"],
+            "approval_ratings": [
+              "fda_prescription"
+            ],
             "approval_year": [],
             "has_indication": []
           },
@@ -3866,7 +3939,9 @@
             "label": "CISPLATIN",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["rxcui:309311"],
+            "xrefs": [
+              "rxcui:309311"
+            ],
             "associated_with": [
               "ndc:16729-288",
               "spl:c43de769-d6d8-3bb9-e053-2995a90a5aa2",
@@ -3874,7 +3949,9 @@
               "spl:c3ddc4a5-9f1b-a8ee-e053-2a95a90a2265",
               "ndc:68001-283"
             ],
-            "approval_ratings": ["fda_prescription"],
+            "approval_ratings": [
+              "fda_prescription"
+            ],
             "approval_year": [],
             "has_indication": []
           },
@@ -3883,7 +3960,9 @@
             "label": "CISPLATIN",
             "aliases": [],
             "trade_names": [],
-            "xrefs": ["rxcui:309311"],
+            "xrefs": [
+              "rxcui:309311"
+            ],
             "associated_with": [
               "ndc:72266-252",
               "spl:0219ee77-eb38-b81f-e063-6394a90a5ca4",
@@ -3897,7 +3976,9 @@
               "ndc:70860-206",
               "ndc:68083-163"
             ],
-            "approval_ratings": ["fda_prescription"],
+            "approval_ratings": [
+              "fda_prescription"
+            ],
             "approval_year": [],
             "has_indication": []
           },
@@ -3905,8 +3986,14 @@
             "concept_id": "drugsatfda.nda:018057",
             "label": "CISPLATIN",
             "aliases": [],
-            "trade_names": ["PLATINOL-AQ", "PLATINOL"],
-            "xrefs": ["rxcui:309311", "rxcui:1736854"],
+            "trade_names": [
+              "PLATINOL-AQ",
+              "PLATINOL"
+            ],
+            "xrefs": [
+              "rxcui:309311",
+              "rxcui:1736854"
+            ],
             "associated_with": [
               "unii:Q20Q21Q62J",
               "ndc:44567-509",
@@ -3939,7 +4026,9 @@
           {
             "concept_id": "iuphar.ligand:5343",
             "label": "cisplatin",
-            "aliases": ["Platinol"],
+            "aliases": [
+              "Platinol"
+            ],
             "trade_names": [],
             "xrefs": [
               "chemidplus:15663-27-1",
@@ -3951,7 +4040,9 @@
               "pubchem.substance:178102005",
               "CHEBI:27899"
             ],
-            "approval_ratings": ["gtopdb_approved"],
+            "approval_ratings": [
+              "gtopdb_approved"
+            ],
             "approval_year": [],
             "has_indication": []
           }
@@ -3999,7 +4090,9 @@
             ],
             "xrefs": [],
             "associated_with": [],
-            "approval_ratings": ["chembl_phase_4"],
+            "approval_ratings": [
+              "chembl_phase_4"
+            ],
             "approval_year": [],
             "has_indication": [
               {
@@ -4988,8 +5081,12 @@
               "1,2-Diaminocyclohexaneplatinum II citrate"
             ],
             "trade_names": [],
-            "xrefs": ["drugbank:DB00515"],
-            "associated_with": ["unii:Q20Q21Q62J"],
+            "xrefs": [
+              "drugbank:DB00515"
+            ],
+            "associated_with": [
+              "unii:Q20Q21Q62J"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []
@@ -5029,7 +5126,9 @@
               "iuphar.ligand:5343",
               "drugbank:DB00515"
             ],
-            "associated_with": ["pubchem.compound:5702198"],
+            "associated_with": [
+              "pubchem.compound:5702198"
+            ],
             "approval_ratings": null,
             "approval_year": [],
             "has_indication": []

--- a/tests/data/fixtures/query_fixtures.json
+++ b/tests/data/fixtures/query_fixtures.json
@@ -4,6 +4,7 @@
     "label": "cisplatin",
     "description": null,
     "id": "normalize.therapy.rxcui:2555",
+    "primaryCode": "rxcui:2555",
     "extensions": [
       {
         "name": "aliases",
@@ -73,7 +74,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7251"
                   },
                   "relation": "relatedMatch"
@@ -93,7 +94,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7431"
                   },
                   "relation": "relatedMatch"
@@ -113,7 +114,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9334"
                   },
                   "relation": "relatedMatch"
@@ -133,7 +134,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3411"
                   },
                   "relation": "relatedMatch"
@@ -193,7 +194,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3262"
                   },
                   "relation": "relatedMatch"
@@ -213,7 +214,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7606"
                   },
                   "relation": "relatedMatch"
@@ -233,7 +234,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2929"
                   },
                   "relation": "relatedMatch"
@@ -253,7 +254,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4436"
                   },
                   "relation": "relatedMatch"
@@ -273,7 +274,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3017"
                   },
                   "relation": "relatedMatch"
@@ -293,7 +294,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7478"
                   },
                   "relation": "relatedMatch"
@@ -313,7 +314,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4917"
                   },
                   "relation": "relatedMatch"
@@ -333,7 +334,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7548"
                   },
                   "relation": "relatedMatch"
@@ -353,7 +354,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2915"
                   },
                   "relation": "relatedMatch"
@@ -373,7 +374,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3222"
                   },
                   "relation": "relatedMatch"
@@ -393,7 +394,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3032"
                   },
                   "relation": "relatedMatch"
@@ -413,7 +414,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3247"
                   },
                   "relation": "relatedMatch"
@@ -433,7 +434,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C8851"
                   },
                   "relation": "relatedMatch"
@@ -453,7 +454,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3149"
                   },
                   "relation": "relatedMatch"
@@ -473,7 +474,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3387"
                   },
                   "relation": "relatedMatch"
@@ -504,7 +505,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3619"
                   },
                   "relation": "relatedMatch"
@@ -524,7 +525,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3468"
                   },
                   "relation": "relatedMatch"
@@ -544,7 +545,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3708"
                   },
                   "relation": "relatedMatch"
@@ -564,7 +565,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2877"
                   },
                   "relation": "relatedMatch"
@@ -584,7 +585,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4962"
                   },
                   "relation": "relatedMatch"
@@ -604,7 +605,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3196"
                   },
                   "relation": "relatedMatch"
@@ -624,7 +625,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7502"
                   },
                   "relation": "relatedMatch"
@@ -644,7 +645,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4699"
                   },
                   "relation": "relatedMatch"
@@ -664,7 +665,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3048"
                   },
                   "relation": "relatedMatch"
@@ -684,7 +685,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4533"
                   },
                   "relation": "relatedMatch"
@@ -704,7 +705,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7190"
                   },
                   "relation": "relatedMatch"
@@ -744,7 +745,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3959"
                   },
                   "relation": "relatedMatch"
@@ -764,7 +765,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C34803"
                   },
                   "relation": "relatedMatch"
@@ -784,7 +785,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7978"
                   },
                   "relation": "relatedMatch"
@@ -804,7 +805,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4890"
                   },
                   "relation": "relatedMatch"
@@ -824,7 +825,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2956"
                   },
                   "relation": "relatedMatch"
@@ -844,7 +845,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3305"
                   },
                   "relation": "relatedMatch"
@@ -864,7 +865,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4013"
                   },
                   "relation": "relatedMatch"
@@ -884,7 +885,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3359"
                   },
                   "relation": "relatedMatch"
@@ -904,7 +905,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3471"
                   },
                   "relation": "relatedMatch"
@@ -924,7 +925,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3568"
                   },
                   "relation": "relatedMatch"
@@ -944,7 +945,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9120"
                   },
                   "relation": "relatedMatch"
@@ -964,7 +965,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2948"
                   },
                   "relation": "relatedMatch"
@@ -995,7 +996,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4001"
                   },
                   "relation": "relatedMatch"
@@ -1015,7 +1016,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9231"
                   },
                   "relation": "relatedMatch"
@@ -1035,7 +1036,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7251"
                   },
                   "relation": "relatedMatch"
@@ -1055,7 +1056,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3512"
                   },
                   "relation": "relatedMatch"
@@ -1075,7 +1076,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3552"
                   },
                   "relation": "relatedMatch"
@@ -1095,7 +1096,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3053"
                   },
                   "relation": "relatedMatch"
@@ -1115,7 +1116,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C115965"
                   },
                   "relation": "relatedMatch"
@@ -1135,7 +1136,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9314"
                   },
                   "relation": "relatedMatch"
@@ -1155,7 +1156,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3242"
                   },
                   "relation": "relatedMatch"
@@ -1175,7 +1176,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C156767"
                   },
                   "relation": "relatedMatch"
@@ -1195,7 +1196,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7398"
                   },
                   "relation": "relatedMatch"
@@ -1215,7 +1216,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3270"
                   },
                   "relation": "relatedMatch"
@@ -1235,7 +1236,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3161"
                   },
                   "relation": "relatedMatch"
@@ -1255,7 +1256,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7545"
                   },
                   "relation": "relatedMatch"
@@ -1275,7 +1276,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3224"
                   },
                   "relation": "relatedMatch"
@@ -1295,7 +1296,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2858"
                   },
                   "relation": "relatedMatch"
@@ -1315,7 +1316,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9357"
                   },
                   "relation": "relatedMatch"
@@ -1335,7 +1336,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9311"
                   },
                   "relation": "relatedMatch"
@@ -1355,7 +1356,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2926"
                   },
                   "relation": "relatedMatch"
@@ -1386,7 +1387,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3915"
                   },
                   "relation": "relatedMatch"
@@ -1406,7 +1407,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2852"
                   },
                   "relation": "relatedMatch"
@@ -1426,7 +1427,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3780"
                   },
                   "relation": "relatedMatch"
@@ -1446,7 +1447,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3011"
                   },
                   "relation": "relatedMatch"
@@ -1466,7 +1467,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2910"
                   },
                   "relation": "relatedMatch"
@@ -1497,7 +1498,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4627"
                   },
                   "relation": "relatedMatch"
@@ -1517,7 +1518,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3811"
                   },
                   "relation": "relatedMatch"
@@ -1537,7 +1538,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3099"
                   },
                   "relation": "relatedMatch"
@@ -1557,7 +1558,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3549"
                   },
                   "relation": "relatedMatch"
@@ -1577,7 +1578,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3403"
                   },
                   "relation": "relatedMatch"
@@ -1597,7 +1598,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3322"
                   },
                   "relation": "relatedMatch"
@@ -1617,7 +1618,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C6014"
                   },
                   "relation": "relatedMatch"
@@ -1637,7 +1638,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C36077"
                   },
                   "relation": "relatedMatch"
@@ -1657,7 +1658,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9309"
                   },
                   "relation": "relatedMatch"
@@ -1677,7 +1678,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7431"
                   },
                   "relation": "relatedMatch"
@@ -1697,7 +1698,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3209"
                   },
                   "relation": "relatedMatch"
@@ -1717,7 +1718,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4044"
                   },
                   "relation": "relatedMatch"
@@ -1737,7 +1738,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3234"
                   },
                   "relation": "relatedMatch"
@@ -1757,7 +1758,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3728"
                   },
                   "relation": "relatedMatch"
@@ -1777,7 +1778,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3752"
                   },
                   "relation": "relatedMatch"
@@ -1797,7 +1798,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3720"
                   },
                   "relation": "relatedMatch"
@@ -1817,7 +1818,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2869"
                   },
                   "relation": "relatedMatch"
@@ -1837,7 +1838,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2916"
                   },
                   "relation": "relatedMatch"
@@ -1857,7 +1858,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3317"
                   },
                   "relation": "relatedMatch"
@@ -1877,7 +1878,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3372"
                   },
                   "relation": "relatedMatch"
@@ -1897,7 +1898,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7541"
                   },
                   "relation": "relatedMatch"
@@ -1917,7 +1918,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9118"
                   },
                   "relation": "relatedMatch"
@@ -1937,7 +1938,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3770"
                   },
                   "relation": "relatedMatch"
@@ -1957,7 +1958,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3208"
                   },
                   "relation": "relatedMatch"
@@ -1977,7 +1978,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3211"
                   },
                   "relation": "relatedMatch"
@@ -1997,7 +1998,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3200"
                   },
                   "relation": "relatedMatch"
@@ -2017,7 +2018,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9334"
                   },
                   "relation": "relatedMatch"
@@ -2037,7 +2038,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3184"
                   },
                   "relation": "relatedMatch"
@@ -2057,7 +2058,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3222"
                   },
                   "relation": "relatedMatch"
@@ -2077,7 +2078,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3012"
                   },
                   "relation": "relatedMatch"
@@ -2097,7 +2098,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C26887"
                   },
                   "relation": "relatedMatch"
@@ -2117,7 +2118,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C4337"
                   },
                   "relation": "relatedMatch"
@@ -2148,7 +2149,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9145"
                   },
                   "relation": "relatedMatch"
@@ -2168,7 +2169,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3794"
                   },
                   "relation": "relatedMatch"
@@ -2188,7 +2189,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3257"
                   },
                   "relation": "relatedMatch"
@@ -2208,7 +2209,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3059"
                   },
                   "relation": "relatedMatch"
@@ -2228,7 +2229,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3790"
                   },
                   "relation": "relatedMatch"
@@ -2259,7 +2260,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C8196"
                   },
                   "relation": "relatedMatch"
@@ -2279,7 +2280,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3156"
                   },
                   "relation": "relatedMatch"
@@ -2299,7 +2300,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C2862"
                   },
                   "relation": "relatedMatch"
@@ -2319,7 +2320,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7528"
                   },
                   "relation": "relatedMatch"
@@ -2339,7 +2340,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3773"
                   },
                   "relation": "relatedMatch"
@@ -2359,7 +2360,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C34797"
                   },
                   "relation": "relatedMatch"
@@ -2379,7 +2380,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7558"
                   },
                   "relation": "relatedMatch"
@@ -2399,7 +2400,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C9345"
                   },
                   "relation": "relatedMatch"
@@ -2419,7 +2420,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C7510"
                   },
                   "relation": "relatedMatch"
@@ -2439,7 +2440,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3868"
                   },
                   "relation": "relatedMatch"
@@ -2459,7 +2460,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C71732"
                   },
                   "relation": "relatedMatch"
@@ -2484,400 +2485,407 @@
     "mappings": [
       {
         "coding": {
-          "code": "C376",
-          "system": "ncit"
+          "code": "rxcui:2555",
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/index.html"
+        },
+        "relation": "exactMatch"
+      },
+      {
+        "coding": {
+          "code": "ncit:C376",
+          "system": "http://purl.obolibrary.org/obo/ncit.owl"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "105",
-          "system": "hemonc"
+          "code": "hemonc:105",
+          "system": "https://hemonc.org"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "DB00515",
-          "system": "drugbank"
+          "code": "drugbank:DB00515",
+          "system": "https://go.drugbank.com"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "DB12117",
-          "system": "drugbank"
+          "code": "drugbank:DB12117",
+          "system": "https://go.drugbank.com"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "074656",
-          "system": "drugsatfda.anda"
+          "code": "drugsatfda.anda:074656",
+          "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "074735",
-          "system": "drugsatfda.anda"
+          "code": "drugsatfda.nda:074735",
+          "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "075036",
-          "system": "drugsatfda.anda"
+          "code": "drugsatfda.anda:075036",
+          "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "206774",
-          "system": "drugsatfda.anda"
+          "code": "drugsatfda.anda:206774",
+          "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "207323",
-          "system": "drugsatfda.anda"
+          "code": "drugsatfda.anda:207323",
+          "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "018057",
-          "system": "drugsatfda.nda"
+          "code": "drugsatfda.nda:018057",
+          "system": "https://www.fda.gov/drugs/types-applications/new-drug-application-nda"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "5343",
-          "system": "iuphar.ligand"
+          "code": "iuphar.ligand:5343",
+          "system": "https://www.guidetopharmacology.org/GRAC/LigandListForward"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "CHEMBL11359",
-          "system": "chembl"
+          "code": "chembl:CHEMBL11359",
+          "system": "https://www.ebi.ac.uk/chembl/"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "15663-27-1",
-          "system": "chemidplus"
+          "code": "chemidplus:15663-27-1",
+          "system": "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "Q412415",
-          "system": "wikidata"
+          "code": "wikidata:Q412415",
+          "system": "https://www.wikidata.org"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "0703-5748",
-          "system": "ndc"
+          "code": "ndc:0703-5748",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "63323-103",
-          "system": "ndc"
+          "code": "ndc:63323-103",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "70860-206",
-          "system": "ndc"
+          "code": "ndc:70860-206",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "44567-509",
-          "system": "ndc"
+          "code": "ndc:44567-509",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "m17910",
-          "system": "usp"
+          "code": "usp:m17910",
+          "system": "https://www.usp.org/health-quality-safety/compendial-nomenclature"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "44567-530",
-          "system": "ndc"
+          "code": "ndc:44567-530",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "178102005",
-          "system": "pubchem.substance"
+          "code": "pubchem.substance:178102005",
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/substances"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "9b008181-ab66-db2f-e053-2995a90aad57",
-          "system": "spl"
+          "code": "spl:9b008181-ab66-db2f-e053-2995a90aad57",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "16729-288",
-          "system": "ndc"
+          "code": "ndc:16729-288",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "a66eda32-1164-439a-ac8e-73138365ec06",
-          "system": "spl"
+          "code": "spl:a66eda32-1164-439a-ac8e-73138365ec06",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "dd45d777-d4c1-40ee-b4f0-c9e001a15a8c",
-          "system": "spl"
+          "code": "spl:dd45d777-d4c1-40ee-b4f0-c9e001a15a8c",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "27899",
-          "system": "chebi"
+          "code": "chebi:27899",
+          "system": "http://purl.obolibrary.org/obo/chebi.owl"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "44567-511",
-          "system": "ndc"
+          "code": "ndc:44567-511",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "0703-5747",
-          "system": "ndc"
+          "code": "ndc:0703-5747",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "68083-162",
-          "system": "ndc"
+          "code": "ndc:68083-162",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "L01XA01",
-          "system": "atc"
+          "code": "atc:L01XA01",
+          "system": "https://www.who.int/tools/atc-ddd-toolkit/atc-classification/"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "44567-510",
-          "system": "ndc"
+          "code": "ndc:44567-510",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "31747",
-          "system": "mmsl"
+          "code": "mmsl:31747",
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "2c569ef0-588f-4828-8b2d-03a2120c9b4c",
-          "system": "spl"
+          "code": "spl:2c569ef0-588f-4828-8b2d-03a2120c9b4c",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "4018139",
-          "system": "vandf"
+          "code": "vandf:4018139",
+          "system": "https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/VANDF"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "LXZZYRPGZAFOLE-UHFFFAOYSA-L",
+          "code": "inchikey:LXZZYRPGZAFOLE-UHFFFAOYSA-L",
           "system": "inchikey"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "68083-163",
-          "system": "ndc"
+          "code": "ndc:68083-163",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "MOTIYCLHZZLHHQ-UHFFFAOYSA-N",
+          "code": "inchikey:MOTIYCLHZZLHHQ-UHFFFAOYSA-N",
           "system": "inchikey"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "adf5773e-9095-4cb4-a90f-72cbf82f4493",
-          "system": "spl"
+          "code": "spl:adf5773e-9095-4cb4-a90f-72cbf82f4493",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "d00195",
-          "system": "mmsl"
+          "code": "mmsl:d00195",
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "01c7a680-ee0d-42da-85e8-8d56c6fe7006",
-          "system": "spl"
+          "code": "spl:01c7a680-ee0d-42da-85e8-8d56c6fe7006",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "c43de769-d6d8-3bb9-e053-2995a90a5aa2",
-          "system": "spl"
+          "code": "spl:c43de769-d6d8-3bb9-e053-2995a90a5aa2",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "H8MTN7XVC2",
-          "system": "unii"
+          "code": "unii:H8MTN7XVC2",
+          "system": "https://precision.fda.gov/uniisearch"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "68001-283",
-          "system": "ndc"
+          "code": "ndc:68001-283",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "Q20Q21Q62J",
-          "system": "unii"
+          "code": "unii:Q20Q21Q62J",
+          "system": "https://precision.fda.gov/uniisearch"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "5702198",
-          "system": "pubchem.compound"
+          "code": "pubchem.compound:5702198",
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/compounds"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "441203",
-          "system": "pubchem.compound"
+          "code": "pubchem.compound441203",
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/compounds"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "0143-9505",
-          "system": "ndc"
+          "code": "ndc:0143-9505",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "c3ddc4a5-9f1b-a8ee-e053-2a95a90a2265",
-          "system": "spl"
+          "code": "spl:c3ddc4a5-9f1b-a8ee-e053-2a95a90a2265",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "4456",
-          "system": "mmsl"
+          "code": "mmsl:4456",
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "C0008838",
-          "system": "umls"
+          "code": "umls:C0008838",
+          "system": "https://www.nlm.nih.gov/research/umls/index.html"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "0219ee77-eb38-b81f-e063-6394a90a5ca4",
-          "system": "spl"
+          "code": "spl:0219ee77-eb38-b81f-e063-6394a90a5ca4",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "89007399-3c34-40d2-8068-a0b8e09cbef8",
-          "system": "spl"
+          "code": "spl:89007399-3c34-40d2-8068-a0b8e09cbef8",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "64bcce1a-6e31-4e73-8da5-11aa9e890da2",
-          "system": "spl"
+          "code": "spl:64bcce1a-6e31-4e73-8da5-11aa9e890da2",
+          "system": "https://www.fda.gov/industry/fda-data-standards-advisory-board/structured-product-labeling-resources"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "72266-253",
-          "system": "ndc"
+          "code": "ndc:72266-253",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "25021-253",
-          "system": "ndc"
+          "code": "ndc:25021-253",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "72266-252",
-          "system": "ndc"
+          "code": "ndc:72266-252",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "code": "0143-9504",
-          "system": "ndc"
+          "code": "ndc:0143-9504",
+          "system": "https://dps.fda.gov/ndc"
         },
         "relation": "relatedMatch"
       }
@@ -2968,7 +2976,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3208"
                   },
                   "relation": "relatedMatch"
@@ -3008,7 +3016,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3020"
                   },
                   "relation": "relatedMatch"
@@ -3028,7 +3036,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C85079"
                   },
                   "relation": "relatedMatch"
@@ -3048,7 +3056,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C87101"
                   },
                   "relation": "relatedMatch"
@@ -3068,7 +3076,7 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "ncit",
+                    "system": "http://purl.obolibrary.org/obo/ncit.owl",
                     "code": "C3980"
                   },
                   "relation": "relatedMatch"
@@ -3156,134 +3164,134 @@
     "mappings": [
       {
         "coding": {
-          "system": "ncit",
-          "code": "C739"
+          "system": "http://purl.obolibrary.org/obo/ncit.owl",
+          "code": "ncit:C739"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "drugbank",
-          "code": "DB01174"
+          "system": "https://go.drugbank.com",
+          "code": "drugbank:DB01174"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "iuphar.ligand",
-          "code": "2804"
+          "system": "https://www.guidetopharmacology.org/GRAC/LigandListForward",
+          "code": "iuphar.ligand:2804"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "chembl",
-          "code": "CHEMBL40"
+          "system": "https://www.ebi.ac.uk/chembl/",
+          "code": "chembl:CHEMBL40"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "chemidplus",
-          "code": "50-06-6"
+          "system": "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus",
+          "code": "chemidplus:50-06-6"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "wikidata",
-          "code": "Q407241"
+          "system": "https://www.wikidata.org",
+          "code": "wikidata:Q407241"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "vandf",
-          "code": "4017422"
+          "system": "https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/VANDF",
+          "code": "vandf:4017422"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "usp",
-          "code": "m63400"
+          "system": "https://www.usp.org/health-quality-safety/compendial-nomenclature",
+          "code": "usp:m63400"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "chebi",
-          "code": "8069"
+          "system": "http://purl.obolibrary.org/obo/chebi.owl",
+          "code": "chebi:8069"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "unii",
-          "code": "YQE403BP4D"
+          "system": "https://precision.fda.gov/uniisearch",
+          "code": "unii:YQE403BP4D"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "atc",
-          "code": "N03AA02"
+          "system": "https://www.who.int/tools/atc-ddd-toolkit/atc-classification/",
+          "code": "atc:N03AA02"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
           "system": "inchikey",
-          "code": "DDBREPKUVSBGFI-UHFFFAOYSA-N"
+          "code": "inchikey:DDBREPKUVSBGFI-UHFFFAOYSA-N"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "umls",
-          "code": "C0031412"
+          "system": "https://www.nlm.nih.gov/research/umls/index.html",
+          "code": "umls:C0031412"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "pubchem.substance",
-          "code": "135650817"
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/substances",
+          "code": "pubchem.substance:135650817"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "mmsl",
-          "code": "d00340"
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html",
+          "code": "mmsl:d00340"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "mmsl",
-          "code": "2390"
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html",
+          "code": "mmsl:2390"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
           "system": "drugcentral",
-          "code": "2134"
+          "code": "drugcentral:2134"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "pubchem.compound",
-          "code": "4763"
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/compounds",
+          "code": "pubchem.compound:4763"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "mmsl",
-          "code": "5272"
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/sourcereleasedocs/mmsl.html",
+          "code": "mmsl:5272"
         },
         "relation": "relatedMatch"
       }
@@ -3296,71 +3304,71 @@
     "mappings": [
       {
         "coding": {
-          "system": "ncit",
-          "code": "C839"
+          "system": "http://purl.obolibrary.org/obo/ncit.owl",
+          "code": "ncit:C839"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "drugbank",
-          "code": "DB06145"
+          "system": "https://go.drugbank.com",
+          "code": "drugbank:DB06145"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "chemidplus",
-          "code": "8025-81-8"
+          "system": "https://pubchem.ncbi.nlm.nih.gov/source/ChemIDplus",
+          "code": "chemidplus:8025-81-8"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "wikidata",
-          "code": "Q422265"
+          "system": "https://www.wikidata.org",
+          "code": "wikidata:Q422265"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "unii",
-          "code": "71ODY0V87H"
+          "system": "https://precision.fda.gov/uniisearch",
+          "code": "unii:71ODY0V87H"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "pubchem.compound",
-          "code": "5356392"
+          "system": "https://pubchem.ncbi.nlm.nih.gov/docs/compounds",
+          "code": "pubchem.compound:5356392"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "atc",
-          "code": "J01FA02"
+          "system": "https://www.who.int/tools/atc-ddd-toolkit/atc-classification/",
+          "code": "atc:J01FA02"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
           "system": "inchikey",
-          "code": "ACTOXUHEUCPTEW-CEUOBAOPSA-N"
+          "code": "inchikey:ACTOXUHEUCPTEW-CEUOBAOPSA-N"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "unii",
-          "code": "033ECH6IFG"
+          "system": "https://precision.fda.gov/uniisearch",
+          "code": "unii:033ECH6IFG"
         },
         "relation": "relatedMatch"
       },
       {
         "coding": {
-          "system": "umls",
-          "code": "C0037962"
+          "system": "https://www.nlm.nih.gov/research/umls/index.html",
+          "code": "umls:C0037962"
         },
         "relation": "relatedMatch"
       }
@@ -3418,8 +3426,8 @@
     "mappings": [
       {
         "coding": {
-          "code": "C0087111",
-          "system": "umls"
+          "code": "umls:C0087111",
+          "system": "https://www.nlm.nih.gov/research/umls/index.html"
         },
         "relation": "relatedMatch"
       }

--- a/tests/data/fixtures/query_fixtures.json
+++ b/tests/data/fixtures/query_fixtures.json
@@ -75,7 +75,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7251"
+                    "code": "ncit:C7251"
                   },
                   "relation": "relatedMatch"
                 }
@@ -95,7 +95,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7431"
+                    "code": "ncit:C7431"
                   },
                   "relation": "relatedMatch"
                 }
@@ -115,7 +115,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9334"
+                    "code": "ncit:C9334"
                   },
                   "relation": "relatedMatch"
                 }
@@ -135,7 +135,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3411"
+                    "code": "ncit:C3411"
                   },
                   "relation": "relatedMatch"
                 }
@@ -154,8 +154,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0850353"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0850353"
                   },
                   "relation": "relatedMatch"
                 }
@@ -174,8 +174,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0003060"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0003060"
                   },
                   "relation": "relatedMatch"
                 }
@@ -195,7 +195,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3262"
+                    "code": "ncit:C3262"
                   },
                   "relation": "relatedMatch"
                 }
@@ -215,7 +215,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7606"
+                    "code": "ncit:C7606"
                   },
                   "relation": "relatedMatch"
                 }
@@ -235,7 +235,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2929"
+                    "code": "ncit:C2929"
                   },
                   "relation": "relatedMatch"
                 }
@@ -255,7 +255,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4436"
+                    "code": "ncit:C4436"
                   },
                   "relation": "relatedMatch"
                 }
@@ -275,7 +275,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3017"
+                    "code": "ncit:C3017"
                   },
                   "relation": "relatedMatch"
                 }
@@ -295,7 +295,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7478"
+                    "code": "ncit:C7478"
                   },
                   "relation": "relatedMatch"
                 }
@@ -315,7 +315,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4917"
+                    "code": "ncit:C4917"
                   },
                   "relation": "relatedMatch"
                 }
@@ -335,7 +335,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7548"
+                    "code": "ncit:C7548"
                   },
                   "relation": "relatedMatch"
                 }
@@ -355,7 +355,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2915"
+                    "code": "ncit:C2915"
                   },
                   "relation": "relatedMatch"
                 }
@@ -375,7 +375,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3222"
+                    "code": "ncit:C3222"
                   },
                   "relation": "relatedMatch"
                 }
@@ -395,7 +395,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3032"
+                    "code": "ncit:C3032"
                   },
                   "relation": "relatedMatch"
                 }
@@ -415,7 +415,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3247"
+                    "code": "ncit:C3247"
                   },
                   "relation": "relatedMatch"
                 }
@@ -435,7 +435,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C8851"
+                    "code": "ncit:C8851"
                   },
                   "relation": "relatedMatch"
                 }
@@ -455,7 +455,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3149"
+                    "code": "ncit:C3149"
                   },
                   "relation": "relatedMatch"
                 }
@@ -475,7 +475,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3387"
+                    "code": "ncit:C3387"
                   },
                   "relation": "relatedMatch"
                 }
@@ -506,7 +506,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3619"
+                    "code": "ncit:C3619"
                   },
                   "relation": "relatedMatch"
                 }
@@ -526,7 +526,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3468"
+                    "code": "ncit:C3468"
                   },
                   "relation": "relatedMatch"
                 }
@@ -546,7 +546,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3708"
+                    "code": "ncit:C3708"
                   },
                   "relation": "relatedMatch"
                 }
@@ -566,7 +566,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2877"
+                    "code": "ncit:C2877"
                   },
                   "relation": "relatedMatch"
                 }
@@ -586,7 +586,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4962"
+                    "code": "ncit:C4962"
                   },
                   "relation": "relatedMatch"
                 }
@@ -606,7 +606,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3196"
+                    "code": "ncit:C3196"
                   },
                   "relation": "relatedMatch"
                 }
@@ -626,7 +626,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7502"
+                    "code": "ncit:C7502"
                   },
                   "relation": "relatedMatch"
                 }
@@ -646,7 +646,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4699"
+                    "code": "ncit:C4699"
                   },
                   "relation": "relatedMatch"
                 }
@@ -666,7 +666,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3048"
+                    "code": "ncit:C3048"
                   },
                   "relation": "relatedMatch"
                 }
@@ -686,7 +686,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4533"
+                    "code": "ncit:C4533"
                   },
                   "relation": "relatedMatch"
                 }
@@ -706,7 +706,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7190"
+                    "code": "ncit:C7190"
                   },
                   "relation": "relatedMatch"
                 }
@@ -725,8 +725,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0005086"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0005086"
                   },
                   "relation": "relatedMatch"
                 }
@@ -746,7 +746,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3959"
+                    "code": "ncit:C3959"
                   },
                   "relation": "relatedMatch"
                 }
@@ -766,7 +766,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C34803"
+                    "code": "ncit:C34803"
                   },
                   "relation": "relatedMatch"
                 }
@@ -786,7 +786,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7978"
+                    "code": "ncit:C7978"
                   },
                   "relation": "relatedMatch"
                 }
@@ -806,7 +806,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4890"
+                    "code": "ncit:C4890"
                   },
                   "relation": "relatedMatch"
                 }
@@ -826,7 +826,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2956"
+                    "code": "ncit:C2956"
                   },
                   "relation": "relatedMatch"
                 }
@@ -846,7 +846,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3305"
+                    "code": "ncit:C3305"
                   },
                   "relation": "relatedMatch"
                 }
@@ -866,7 +866,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4013"
+                    "code": "ncit:C4013"
                   },
                   "relation": "relatedMatch"
                 }
@@ -886,7 +886,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3359"
+                    "code": "ncit:C3359"
                   },
                   "relation": "relatedMatch"
                 }
@@ -906,7 +906,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3471"
+                    "code": "ncit:C3471"
                   },
                   "relation": "relatedMatch"
                 }
@@ -926,7 +926,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3568"
+                    "code": "ncit:C3568"
                   },
                   "relation": "relatedMatch"
                 }
@@ -946,7 +946,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9120"
+                    "code": "ncit:C9120"
                   },
                   "relation": "relatedMatch"
                 }
@@ -966,7 +966,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2948"
+                    "code": "ncit:C2948"
                   },
                   "relation": "relatedMatch"
                 }
@@ -997,7 +997,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4001"
+                    "code": "ncit:C4001"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1017,7 +1017,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9231"
+                    "code": "ncit:C9231"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1037,7 +1037,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7251"
+                    "code": "ncit:C7251"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1057,7 +1057,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3512"
+                    "code": "ncit:C3512"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1077,7 +1077,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3552"
+                    "code": "ncit:C3552"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1097,7 +1097,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3053"
+                    "code": "ncit:C3053"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1117,7 +1117,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C115965"
+                    "code": "ncit:C115965"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1137,7 +1137,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9314"
+                    "code": "ncit:C9314"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1157,7 +1157,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3242"
+                    "code": "ncit:C3242"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1177,7 +1177,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C156767"
+                    "code": "ncit:C156767"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1197,7 +1197,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7398"
+                    "code": "ncit:C7398"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1217,7 +1217,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3270"
+                    "code": "ncit:C3270"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1237,7 +1237,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3161"
+                    "code": "ncit:C3161"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1257,7 +1257,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7545"
+                    "code": "ncit:C7545"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1277,7 +1277,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3224"
+                    "code": "ncit:C3224"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1297,7 +1297,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2858"
+                    "code": "ncit:C2858"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1317,7 +1317,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9357"
+                    "code": "ncit:C9357"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1337,7 +1337,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9311"
+                    "code": "ncit:C9311"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1357,7 +1357,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2926"
+                    "code": "ncit:C2926"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1388,7 +1388,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3915"
+                    "code": "ncit:C3915"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1408,7 +1408,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2852"
+                    "code": "ncit:C2852"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1428,7 +1428,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3780"
+                    "code": "ncit:C3780"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1448,7 +1448,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3011"
+                    "code": "ncit:C3011"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1468,7 +1468,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2910"
+                    "code": "ncit:C2910"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1499,7 +1499,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4627"
+                    "code": "ncit:C4627"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1519,7 +1519,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3811"
+                    "code": "ncit:C3811"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1539,7 +1539,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3099"
+                    "code": "ncit:C3099"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1559,7 +1559,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3549"
+                    "code": "ncit:C3549"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1579,7 +1579,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3403"
+                    "code": "ncit:C3403"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1599,7 +1599,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3322"
+                    "code": "ncit:C3322"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1619,7 +1619,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C6014"
+                    "code": "ncit:C6014"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1639,7 +1639,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C36077"
+                    "code": "ncit:C36077"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1659,7 +1659,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9309"
+                    "code": "ncit:C9309"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1679,7 +1679,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7431"
+                    "code": "ncit:C7431"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1699,7 +1699,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3209"
+                    "code": "ncit:C3209"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1719,7 +1719,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4044"
+                    "code": "ncit:C4044"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1739,7 +1739,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3234"
+                    "code": "ncit:C3234"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1759,7 +1759,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3728"
+                    "code": "ncit:C3728"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1779,7 +1779,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3752"
+                    "code": "ncit:C3752"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1799,7 +1799,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3720"
+                    "code": "ncit:C3720"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1819,7 +1819,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2869"
+                    "code": "ncit:C2869"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1839,7 +1839,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2916"
+                    "code": "ncit:C2916"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1859,7 +1859,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3317"
+                    "code": "ncit:C3317"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1879,7 +1879,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3372"
+                    "code": "ncit:C3372"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1899,7 +1899,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7541"
+                    "code": "ncit:C7541"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1919,7 +1919,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9118"
+                    "code": "ncit:C9118"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1939,7 +1939,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3770"
+                    "code": "ncit:C3770"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1959,7 +1959,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3208"
+                    "code": "ncit:C3208"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1979,7 +1979,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3211"
+                    "code": "ncit:C3211"
                   },
                   "relation": "relatedMatch"
                 }
@@ -1999,7 +1999,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3200"
+                    "code": "ncit:C3200"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2019,7 +2019,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9334"
+                    "code": "ncit:C9334"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2039,7 +2039,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3184"
+                    "code": "ncit:C3184"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2059,7 +2059,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3222"
+                    "code": "ncit:C3222"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2079,7 +2079,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3012"
+                    "code": "ncit:C3012"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2099,7 +2099,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C26887"
+                    "code": "ncit:C26887"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2119,7 +2119,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C4337"
+                    "code": "ncit:C4337"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2150,7 +2150,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9145"
+                    "code": "ncit:C9145"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2170,7 +2170,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3794"
+                    "code": "ncit:C3794"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2190,7 +2190,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3257"
+                    "code": "ncit:C3257"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2210,7 +2210,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3059"
+                    "code": "ncit:C3059"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2230,7 +2230,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3790"
+                    "code": "ncit:C3790"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2261,7 +2261,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C8196"
+                    "code": "ncit:C8196"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2281,7 +2281,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3156"
+                    "code": "ncit:C3156"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2301,7 +2301,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C2862"
+                    "code": "ncit:C2862"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2321,7 +2321,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7528"
+                    "code": "ncit:C7528"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2341,7 +2341,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3773"
+                    "code": "ncit:C3773"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2361,7 +2361,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C34797"
+                    "code": "ncit:C34797"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2381,7 +2381,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7558"
+                    "code": "ncit:C7558"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2401,7 +2401,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C9345"
+                    "code": "ncit:C9345"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2421,7 +2421,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C7510"
+                    "code": "ncit:C7510"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2441,7 +2441,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3868"
+                    "code": "ncit:C3868"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2461,7 +2461,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C71732"
+                    "code": "ncit:C71732"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2527,7 +2527,7 @@
       },
       {
         "coding": {
-          "code": "drugsatfda.nda:074735",
+          "code": "drugsatfda.anda:074735",
           "system": "https://www.fda.gov/drugs/types-applications/abbreviated-new-drug-application-anda"
         },
         "relation": "relatedMatch"
@@ -2667,7 +2667,7 @@
       },
       {
         "coding": {
-          "code": "chebi:27899",
+          "code": "CHEBI:27899",
           "system": "http://purl.obolibrary.org/obo/chebi.owl"
         },
         "relation": "relatedMatch"
@@ -2731,7 +2731,7 @@
       {
         "coding": {
           "code": "inchikey:LXZZYRPGZAFOLE-UHFFFAOYSA-L",
-          "system": "inchikey"
+          "system": "https://www.chemspider.com"
         },
         "relation": "relatedMatch"
       },
@@ -2745,7 +2745,7 @@
       {
         "coding": {
           "code": "inchikey:MOTIYCLHZZLHHQ-UHFFFAOYSA-N",
-          "system": "inchikey"
+          "system": "https://www.chemspider.com"
         },
         "relation": "relatedMatch"
       },
@@ -2807,7 +2807,7 @@
       },
       {
         "coding": {
-          "code": "pubchem.compound441203",
+          "code": "pubchem.compound:441203",
           "system": "https://pubchem.ncbi.nlm.nih.gov/docs/compounds"
         },
         "relation": "relatedMatch"
@@ -2893,6 +2893,7 @@
   },
   "normalize_phenobarbital": {
     "id": "normalize.therapy.rxcui:8134",
+    "primaryCode": "rxcui:8134",
     "label": "phenobarbital",
     "extensions": [
       {
@@ -2916,8 +2917,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0001627"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0001627"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2936,8 +2937,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0001475"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0001475"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2956,8 +2957,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0002050"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0002050"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2977,7 +2978,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3208"
+                    "code": "ncit:C3208"
                   },
                   "relation": "relatedMatch"
                 }
@@ -2996,8 +2997,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0005090"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0005090"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3017,7 +3018,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3020"
+                    "code": "ncit:C3020"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3037,7 +3038,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C85079"
+                    "code": "ncit:C85079"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3057,7 +3058,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C87101"
+                    "code": "ncit:C87101"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3077,7 +3078,7 @@
                 {
                   "coding": {
                     "system": "http://purl.obolibrary.org/obo/ncit.owl",
-                    "code": "C3980"
+                    "code": "ncit:C3980"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3096,8 +3097,8 @@
               "mappings": [
                 {
                   "coding": {
-                    "system": "mondo",
-                    "code": "0011918"
+                    "system": "http://purl.obolibrary.org/obo/mondo.owl",
+                    "code": "mondo:0011918"
                   },
                   "relation": "relatedMatch"
                 }
@@ -3164,6 +3165,13 @@
     "mappings": [
       {
         "coding": {
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+          "code": "rxcui:8134"
+        },
+        "relation": "exactMatch"
+      },
+      {
+        "coding": {
           "system": "http://purl.obolibrary.org/obo/ncit.owl",
           "code": "ncit:C739"
         },
@@ -3221,7 +3229,7 @@
       {
         "coding": {
           "system": "http://purl.obolibrary.org/obo/chebi.owl",
-          "code": "chebi:8069"
+          "code": "CHEBI:8069"
         },
         "relation": "relatedMatch"
       },
@@ -3241,7 +3249,7 @@
       },
       {
         "coding": {
-          "system": "inchikey",
+          "system": "https://www.chemspider.com",
           "code": "inchikey:DDBREPKUVSBGFI-UHFFFAOYSA-N"
         },
         "relation": "relatedMatch"
@@ -3276,7 +3284,7 @@
       },
       {
         "coding": {
-          "system": "drugcentral",
+          "system": "https://drugcentral.org",
           "code": "drugcentral:2134"
         },
         "relation": "relatedMatch"
@@ -3300,8 +3308,16 @@
   },
   "normalize_spiramycin": {
     "id": "normalize.therapy.rxcui:9991",
+    "primaryCode": "rxcui:9991",
     "label": "spiramycin",
     "mappings": [
+      {
+        "coding": {
+          "system": "https://www.nlm.nih.gov/research/umls/rxnorm/index.html",
+          "code": "rxcui:9991"
+        },
+        "relation": "exactMatch"
+      },
       {
         "coding": {
           "system": "http://purl.obolibrary.org/obo/ncit.owl",
@@ -3353,7 +3369,7 @@
       },
       {
         "coding": {
-          "system": "inchikey",
+          "system": "https://www.chemspider.com",
           "code": "inchikey:ACTOXUHEUCPTEW-CEUOBAOPSA-N"
         },
         "relation": "relatedMatch"
@@ -3402,6 +3418,7 @@
     "label": "Therapeutic Procedure",
     "description": null,
     "id": "normalize.therapy.ncit:C49236",
+    "primaryCode": "ncit:C49236",
     "extensions": [
       {
         "name": "aliases",
@@ -3424,6 +3441,13 @@
       }
     ],
     "mappings": [
+      {
+        "coding": {
+          "system": "http://purl.obolibrary.org/obo/ncit.owl",
+          "code": "ncit:C49236"
+        },
+        "relation": "exactMatch"
+      },
       {
         "coding": {
           "code": "umls:C0087111",

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -138,7 +138,9 @@ def compare_ta(response, fixture, query, match_type, warnings=None):
     assert response.match_type == match_type
 
     fixture = MappableConcept(**fixture.copy())
-    assert response.normalized_id == fixture.id.split("normalize.therapy.")[-1]
+    assert (
+        response["therapy"]["primaryCode"] == fixture.id.split("normalize.therapy.")[-1]
+    )
     actual = response.therapy
     actual_keys = actual.model_dump(exclude_none=True).keys()
     fixture_keys = fixture.model_dump(exclude_none=True).keys()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -139,7 +139,7 @@ def compare_ta(response, fixture, query, match_type, warnings=None):
 
     fixture = MappableConcept(**fixture.copy())
     assert (
-        response["therapy"]["primaryCode"] == fixture.id.split("normalize.therapy.")[-1]
+        response.therapy.primaryCode.root == fixture.id.split("normalize.therapy.")[-1]
     )
     actual = response.therapy
     actual_keys = actual.model_dump(exclude_none=True).keys()

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
-from ga4gh.core import domain_models
+from ga4gh.core.models import MappableConcept
 
 from therapy.database.database import AbstractDatabase
 from therapy.query import InvalidParameterError, QueryHandler
@@ -107,10 +107,10 @@ def unmerged_normalized_spiramycin(fixture_data):
 
 
 def compare_ta(response, fixture, query, match_type, warnings=None):
-    """Verify correctness of returned core therapeutic agent object against test fixture
+    """Verify correctness of returned core therapy object against test fixture
 
     :param Dict response: actual response
-    :param Dict fixture: expected therapeutic agent object
+    :param Dict fixture: expected therapy object
     :param str query: query used in search
     :param MatchType match_type: expected MatchType
     :param List warnings: expected warnings
@@ -137,15 +137,15 @@ def compare_ta(response, fixture, query, match_type, warnings=None):
 
     assert response.match_type == match_type
 
-    fixture = domain_models.TherapeuticAgent(**fixture.copy())
+    fixture = MappableConcept(**fixture.copy())
     assert response.normalized_id == fixture.id.split("normalize.therapy.")[-1]
-    actual = response.therapeutic_agent
+    actual = response.therapy
     actual_keys = actual.model_dump(exclude_none=True).keys()
     fixture_keys = fixture.model_dump(exclude_none=True).keys()
     assert actual_keys == fixture_keys
 
     assert actual.id == fixture.id
-    assert actual.type == fixture.type
+    assert actual.conceptType == fixture.conceptType
     assert actual.label == fixture.label
 
     assert bool(actual.mappings) == bool(fixture.mappings)
@@ -161,10 +161,6 @@ def compare_ta(response, fixture, query, match_type, warnings=None):
                 no_matches.append(actual_mapping)
         assert no_matches == [], no_matches
         assert len(actual.mappings) == len(fixture.mappings)
-
-    assert bool(actual.alternativeLabels) == bool(fixture.alternativeLabels)
-    if actual.alternativeLabels:
-        assert set(actual.alternativeLabels) == set(fixture.alternativeLabels)
 
     def get_extension(extensions, name):
         matches = [e for e in extensions if e.name == name]


### PR DESCRIPTION
close #448 

* Update modules to vrs [2.0.0-ballot.2024-11.3](https://github.com/ga4gh/vrs/tree/2.0.0-ballot.2024-11.3) tag
  * Use preferred formats for `MappableConcept.mappings`
    * `system` will use OBO Foundry persistent URL (PURL), source homepage,
  or namespace prefix, in that order of preference, if available.
    * `code` will use the `concept_id` as the CURIE
  * Remove `normalized_id` and leverage `MappableConcept.primaryCode`
    * Also updates mappings to include exactMatch relation for merged concept identifier  
* Therapeutic Agent --> Therapy