### PR TITLE
fix(build): add disease-normalizer as required dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "click",
     "boto3",
     "ga4gh.vrs==2.0.0a13",
+    "disease-normalizer~=0.7.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Forgot to add this in #449 🤦‍♀️ Disease normalizer is now required since we use its schemas in the QueryHandler

I'm wondering if we should consider updating cicd tests to install minimal deps needed to help prevent bugs like this in the future