### PR TITLE
fix: resolve pydantic serializer warnings in `_add_merged_meta`

### DIFF
--- a/src/therapy/query.py
+++ b/src/therapy/query.py
@@ -369,7 +369,7 @@ class QueryHandler:
 
         for src in sources:
             if src not in sources_meta:
-                sources_meta[src] = self.db.get_source_metadata(src)
+                sources_meta[SourceName[src.upper()]] = self.db.get_source_metadata(src)
         response.source_meta_ = sources_meta  # type: ignore[assignment]
         return response
 


### PR DESCRIPTION
close #458

* `source_meta` key should have type `SourceName` not `str`