### PR TITLE
build: tighten VRS-Python version restriction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "uvicorn",
     "click",
     "boto3",
-    "ga4gh.vrs==2.*",
+    "ga4gh.vrs>=2.1.3,<3.0",
     "disease-normalizer~=0.11.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Ensure interoperability and avoid issues stemming from earlier VRS-Python releases