### PR TITLE
fix: ensure silent arg is available for merge

### DIFF
--- a/src/therapy/etl/update.py
+++ b/src/therapy/etl/update.py
@@ -201,7 +201,7 @@ def update_normalized(
         _logger.exception(msg)
         click.get_current_context().exit()
 
-    merge = Merge(database=db)
+    merge = Merge(database=db, silent=silent)
     if not silent:
         click.echo("Constructing normalized records...")
     merge.create_merged_concepts(processed_ids)


### PR DESCRIPTION
ensures that `silent` is available to the `Merge` class, meaning that optionally you can enable things like tqdm to print to the console